### PR TITLE
getDatabases response type fix

### DIFF
--- a/src/userbase-js/types/index.d.ts
+++ b/src/userbase-js/types/index.d.ts
@@ -120,7 +120,7 @@ export interface Userbase {
 
   openDatabase(params: { databaseName?: string, databaseId?: string, changeHandler: DatabaseChangeHandler }): Promise<void>
 
-  getDatabases(params?: { databaseName?: string, databaseId?: string }): Promise<DatabasesResult[]>
+  getDatabases(params?: { databaseName?: string, databaseId?: string }): Promise<DatabasesResult>
 
   insertItem(params: { databaseName?: string, databaseId?: string, item: any, itemId?: string }): Promise<void>
 


### PR DESCRIPTION
Tiny fix from
```
getDatabases(params?: { databaseName?: string, databaseId?: string }): Promise<DatabasesResult[]>
```
To
```
getDatabases(params?: { databaseName?: string, databaseId?: string }): Promise<DatabasesResult>
```