### PR TITLE
fix #220: add progress handler callback function to uploadFile

### DIFF
--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -1148,7 +1148,10 @@ const uploadFile = async (params) => {
 
         chunkNumber += 1
         position += FILE_CHUNK_SIZE
-        params.progressHandler({ bytesTransferred: position })
+
+        if (params.progressHandler) {
+          params.progressHandler({ bytesTransferred: position })
+        }
       }
 
       await Promise.all(batch)

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -1148,6 +1148,7 @@ const uploadFile = async (params) => {
 
         chunkNumber += 1
         position += FILE_CHUNK_SIZE
+        params.progressHandler({ bytesTransferred: position })
       }
 
       await Promise.all(batch)

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -1055,9 +1055,9 @@ const _readBlob = async (blob) => {
   })
 }
 
-const _uploadChunkRequest = async (request, bytesTransferredObject, progressHandler) => {
+const _uploadChunkRequest = async (request, bytesTransferredObject, progressHandler, chunkSize) => {
   await request
-  bytesTransferredObject.bytesTransferred += FILE_CHUNK_SIZE;
+  bytesTransferredObject.bytesTransferred += chunkSize;
   if (progressHandler) progressHandler({ ...bytesTransferredObject })
 }
 
@@ -1082,7 +1082,7 @@ const _uploadChunk = async (batch, chunk, dbId, fileId, fileEncryptionKey, chunk
   // queue UploadFileChunk request into batch of requests
   const action = 'UploadFileChunk'
   
-  const uploadChunkRequest = _uploadChunkRequest(ws.request(action, uploadChunkParams), bytesTransferredObject, progressHandler)
+  const uploadChunkRequest = _uploadChunkRequest(ws.request(action, uploadChunkParams), bytesTransferredObject, progressHandler, chunk.size)
 
   batch.push(uploadChunkRequest)
 


### PR DESCRIPTION
This fixes #220. I did not wrap the `ws.request` in a promise as suggested, because I thought this was easier  since the transferred size is calculated already.