### PR TITLE
Encryption modes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,7 +48,7 @@ jobs:
           npm run ci:install
           npm run build:userbase-js:script
       - name: Run Browser Tests
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v2
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         with:

--- a/cypress/config/ci.json
+++ b/cypress/config/ci.json
@@ -3,6 +3,7 @@
     "endpoint": "http://localhost:8080/v1",
     "appId": "004b7892-785a-450c-aa8a-1a66cff23d6e",
     "dbName": "test",
+    "serverSideEncryptionModeAppId": "server-side-app-id",
     "RETRIES": 2
   },
   "firefoxGcInterval": {

--- a/cypress/config/development.json
+++ b/cypress/config/development.json
@@ -5,6 +5,7 @@
     "key": "CKLjtFyavUQkr5lCevkvpCggVoaoo0tTuCAG8h99dGo=",
     "endpoint": "http://localhost:8080/v1",
     "appId": "test-id",
-    "dbName": "test"
+    "dbName": "test",
+    "serverSideEncryptionModeAppId": "server-side-app-id"
   }
 }

--- a/cypress/integration/Admin API/app.spec.js
+++ b/cypress/integration/Admin API/app.spec.js
@@ -109,10 +109,11 @@ describe('GetApp', function () {
           .then(function (response) {
             expect(response.status, 'status').to.eq(200)
 
-            expect(response.body, 'app keys').to.have.keys(['appId', 'appName', 'creationDate', 'paymentsMode'])
+            expect(response.body, 'app keys').to.have.keys(['appId', 'appName', 'creationDate', 'paymentsMode', 'encryptionMode'])
             expect(response.body.appId, 'app appId').to.eq(appId)
             expect(response.body.appName, 'app name').to.eq('Trial')
             expect(response.body.paymentsMode, 'paymentsMode').to.eq('disabled')
+            expect(response.body.encryptionMode, 'encryptionMode').to.eq('end-to-end')
 
             cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
           })
@@ -657,11 +658,12 @@ describe('ListApps', function () {
 
             const app = response.body.apps[0]
 
-            expect(app, 'app keys').to.have.keys(['appId', 'appName', 'creationDate', 'paymentsMode'])
+            expect(app, 'app keys').to.have.keys(['appId', 'appName', 'creationDate', 'paymentsMode', 'encryptionMode'])
 
             expect(app.appId, 'app appId').to.eq(appId)
             expect(app.appName, 'app name').to.eq('Trial')
             expect(app.paymentsMode, 'paymentsMode').to.eq('disabled')
+            expect(response.body.encryptionMode, 'encryptionMode').to.eq('end-to-end')
 
             cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
           })
@@ -692,10 +694,11 @@ describe('ListApps', function () {
 
             const app = response.body.apps[0]
 
-            expect(app, 'app keys').to.have.keys(['appId', 'appName', 'creationDate', 'paymentsMode'])
+            expect(app, 'app keys').to.have.keys(['appId', 'appName', 'creationDate', 'paymentsMode', 'encryptionMode'])
             expect(app.appId, 'app appId').to.eq(appId)
             expect(app.appName, 'app name').to.eq('Trial')
             expect(app.paymentsMode, 'paymentsMode').to.eq('disabled')
+            expect(response.body.encryptionMode, 'encryptionMode').to.eq('end-to-end')
 
             const nextPageToken = constructNextPageToken({ 'admin-id': adminId, 'app-name': 'Trial' })
 

--- a/cypress/integration/Admin API/app.spec.js
+++ b/cypress/integration/Admin API/app.spec.js
@@ -663,7 +663,7 @@ describe('ListApps', function () {
             expect(app.appId, 'app appId').to.eq(appId)
             expect(app.appName, 'app name').to.eq('Trial')
             expect(app.paymentsMode, 'paymentsMode').to.eq('disabled')
-            expect(response.body.encryptionMode, 'encryptionMode').to.eq('end-to-end')
+            expect(app.encryptionMode, 'encryptionMode').to.eq('end-to-end')
 
             cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
           })
@@ -698,7 +698,7 @@ describe('ListApps', function () {
             expect(app.appId, 'app appId').to.eq(appId)
             expect(app.appName, 'app name').to.eq('Trial')
             expect(app.paymentsMode, 'paymentsMode').to.eq('disabled')
-            expect(response.body.encryptionMode, 'encryptionMode').to.eq('end-to-end')
+            expect(app.encryptionMode, 'encryptionMode').to.eq('end-to-end')
 
             const nextPageToken = constructNextPageToken({ 'admin-id': adminId, 'app-name': 'Trial' })
 

--- a/cypress/integration/Database Correctness/file-storage.spec.js
+++ b/cypress/integration/Database Correctness/file-storage.spec.js
@@ -1,5 +1,5 @@
 
-import { getRandomString, wait, readBlobAsText, readBlobAsArrayBuffer } from '../support/utils'
+import { getRandomString, wait, readBlobAsText, readBlobAsArrayBuffer } from '../../support/utils'
 
 const databaseName = 'test-db'
 
@@ -644,7 +644,7 @@ describe('File Storage', function () {
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
 
@@ -1295,7 +1295,7 @@ describe('File Storage', function () {
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
 

--- a/cypress/integration/Database Sharing/modify-permissions.spec.js
+++ b/cypress/integration/Database Sharing/modify-permissions.spec.js
@@ -634,7 +634,7 @@ describe('DB Sharing Tests', function () {
           throw new Error('Should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
 

--- a/cypress/integration/Database Sharing/share-database.spec.js
+++ b/cypress/integration/Database Sharing/share-database.spec.js
@@ -998,7 +998,7 @@ describe('DB Sharing Tests', function () {
           throw new Error('Should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
 

--- a/cypress/integration/Database Sharing/share-database.spec.js
+++ b/cypress/integration/Database Sharing/share-database.spec.js
@@ -434,6 +434,7 @@ describe('DB Sharing Tests', function () {
           receivedFromUsername: sender.username,
           readOnly: true,
           resharingAllowed: false,
+          encryptionMode: 'end-to-end',
           users: [{
             username: sender.username,
             isOwner: true,
@@ -455,6 +456,7 @@ describe('DB Sharing Tests', function () {
           isOwner: true,
           readOnly: false,
           resharingAllowed: true,
+          encryptionMode: 'end-to-end',
           users: [{
             username: recipient.username,
             receivedFromUsername: sender.username,
@@ -530,6 +532,7 @@ describe('DB Sharing Tests', function () {
             isOwner: false,
             readOnly: true,
             resharingAllowed: false,
+            encryptionMode: 'end-to-end',
             users: [{
               username: sender.username,
               isOwner: true,
@@ -589,6 +592,7 @@ describe('DB Sharing Tests', function () {
             isOwner: true,
             readOnly: false,
             resharingAllowed: true,
+            encryptionMode: 'end-to-end',
             users: [{
               username: secondRecipient.username,
               verified: true,

--- a/cypress/integration/Database Sharing/verification.spec.js
+++ b/cypress/integration/Database Sharing/verification.spec.js
@@ -235,6 +235,7 @@ describe('DB Sharing Tests', function () {
         isOwner: false,
         readOnly: true,
         resharingAllowed: true,
+        encryptionMode: 'end-to-end',
       }
     }
 

--- a/cypress/integration/db.server-side-encryption.spec.js
+++ b/cypress/integration/db.server-side-encryption.spec.js
@@ -8,9 +8,9 @@ const beforeEachHook = function () {
     const userbase = win.userbase
     this.currentTest.userbase = userbase
 
-    const { appId, endpoint } = Cypress.env()
+    const { serverSideEncryptionModeAppId, endpoint } = Cypress.env()
     win._userbaseEndpoint = endpoint
-    userbase.init({ appId })
+    userbase.init({ appId: serverSideEncryptionModeAppId })
 
     const randomUser = 'test-user-' + getRandomString()
     const password = getRandomString()
@@ -253,7 +253,7 @@ describe('DB Tests', function () {
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
       })
@@ -510,7 +510,7 @@ describe('DB Tests', function () {
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
       })
@@ -842,7 +842,7 @@ describe('DB Tests', function () {
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
       })
@@ -1206,7 +1206,7 @@ describe('DB Tests', function () {
           isOwner: true,
           readOnly: false,
           resharingAllowed: true,
-          encryptionMode: 'end-to-end',
+          encryptionMode: 'server-side',
           users: []
         })
 
@@ -1237,7 +1237,7 @@ describe('DB Tests', function () {
           expect(readOnly, 'readOnly').to.be.false
           expect(resharingAllowed, 'resharingAllowed').to.be.true
           expect(users, 'users').to.deep.equal([])
-          expect(encryptionMode, 'encryptionMode').to.equal('end-to-end')
+          expect(encryptionMode, 'encryptionMode').to.equal('server-side')
 
           const databaseName = database.databaseName
 
@@ -1268,7 +1268,7 @@ describe('DB Tests', function () {
           isOwner: true,
           readOnly: false,
           resharingAllowed: true,
-          encryptionMode: 'end-to-end',
+          encryptionMode: 'server-side',
           users: []
         })
 
@@ -1315,7 +1315,7 @@ describe('DB Tests', function () {
           isOwner: false,
           readOnly: true,
           resharingAllowed: false,
-          encryptionMode: 'end-to-end',
+          encryptionMode: 'server-side',
           receivedFromUsername: usernameB,
           users: [{
             username: usernameB,
@@ -1353,7 +1353,7 @@ describe('DB Tests', function () {
           isOwner: true,
           readOnly: false,
           resharingAllowed: true,
-          encryptionMode: 'end-to-end',
+          encryptionMode: 'server-side',
           users: []
         })
 
@@ -1434,7 +1434,7 @@ describe('DB Tests', function () {
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
       })

--- a/cypress/integration/db.spec.js
+++ b/cypress/integration/db.spec.js
@@ -253,7 +253,7 @@ describe('DB Tests', function () {
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
       })
@@ -510,7 +510,7 @@ describe('DB Tests', function () {
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
       })
@@ -842,7 +842,7 @@ describe('DB Tests', function () {
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
       })
@@ -1434,7 +1434,7 @@ describe('DB Tests', function () {
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
-          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 100 characters.')
           expect(e.status, 'error status').to.equal(400)
         }
       })

--- a/src/proof-of-concept/server/app.js
+++ b/src/proof-of-concept/server/app.js
@@ -34,6 +34,9 @@ const POC_APP_ID = 'poc-id'
 const TEST_APP_NAME = 'test-integration'
 const TEST_APP_ID = 'test-id'
 
+const SERVER_SIDE_ENCRYPTION_MODE_APP_NAME = 'test-server-side-encryption-mode'
+const SERVER_SIDE_ENCRYPTION_MODE_APP_ID = 'server-side-app-id'
+
 const CONFLICT_STATUS_CODE = 409
 
 start()
@@ -74,6 +77,10 @@ async function setupApps() {
     await Promise.all([
       userbaseServer.createApp({ appName: POC_APP_NAME, adminId: ADMIN_ID, appId: POC_APP_ID }),
       userbaseServer.createApp({ appName: TEST_APP_NAME, adminId: ADMIN_ID, appId: TEST_APP_ID }),
+      userbaseServer.createApp({
+        appName: SERVER_SIDE_ENCRYPTION_MODE_APP_NAME, adminId: ADMIN_ID,
+        appId: SERVER_SIDE_ENCRYPTION_MODE_APP_ID, encryptionMode: 'server-side'
+      })
     ])
   } catch (e) {
     if (!e || e.status !== CONFLICT_STATUS_CODE) {

--- a/src/userbase-js/CHANGELOG.md
+++ b/src/userbase-js/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2.4.0] - 2020-11-24
+### Added
+- Encryption modes 'end-to-end' or 'server-side' set by the admin in the Admin panel are respected by the client. Databases created in 'end-to-end' mode remain end-to-end encrypted same as before (the default behavior). Databases created in 'server-side' mode store the plaintext database encryption key on the server; these databases can be recovered if a user forgets their password and loses access to their device.
+- getDatabases() returns a database's `encryptionMode`.
+- sign() returns a boolean `changePassword` if the user needs to change their password to access database and payments functions in the SDK.
+- forgotPassword() accepts a new optional parameter `deleteEndToEndEncryptedData` to allow users of an app with encryption mode set to 'end-to-end' who forget their password and lose access to their device to regain access to their account.
+- openDatabase(), insertItem(), updateItem(), putTransaction(), uploadFile(), and getFile() all take a new optional parameter `encryptionMode` to override an app's default behavior for a database.
+
+### Fixed
+- signIn() signs in correctly when a user provides the correct password but their seed stored in browser storage is incorrect, rather than throw ServiceUnavailable.
+- init() returns the `lastUsedUsername` when a user's seed stored in browser storage is incorrect, rather than throw ServiceUnavailable.
+
 ## [2.3.0] - 2020-10-26
 ### Added
 - uploadFile() now accepts an optional `progressHandler` callback, which passes total `bytesTransferred` back to the caller every 512 KB uploaded.
@@ -5,7 +17,7 @@
 ### Changed
 - `databaseName` can now be up to 100 characters, rather than 50 characters.
 - forgotPassword() gives a more user-friendly error message if the user attempts to call it from a device that does not have their key saved.
-- signIn() gives a more user-friendly error message if the user attempts to sign in using a temporary password from a device that does not ahve their key saved.
+- signIn() gives a more user-friendly error message if the user attempts to sign in using a temporary password from a device that does not have their key saved.
 
 ### Fixed
 - typescript file's getDatabases() returns correct object type.

--- a/src/userbase-js/src/api/auth.js
+++ b/src/userbase-js/src/api/auth.js
@@ -155,20 +155,6 @@ const getPublicKey = (username) => {
   })
 }
 
-const forgotPasswordDeleteEndToEndEncryptedData = (username) => {
-  return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest()
-
-    const method = 'POST'
-    const url = `${config.getEndpoint()}/api/auth/forgot-password-delete-end-to-end-encrypted-data?appId=${config.getAppId()}&username=${encodeURIComponent(username)}&userbaseJsVersion=${config.USERBASE_JS_VERSION}`
-
-    xhr.open(method, url)
-    xhr.send()
-
-    processXhr(xhr, resolve, reject)
-  })
-}
-
 export default {
   signUp,
   getPasswordSalts,
@@ -176,5 +162,4 @@ export default {
   signInWithSession,
   getServerPublicKey,
   getPublicKey,
-  forgotPasswordDeleteEndToEndEncryptedData,
 }

--- a/src/userbase-js/src/api/auth.js
+++ b/src/userbase-js/src/api/auth.js
@@ -155,6 +155,20 @@ const getPublicKey = (username) => {
   })
 }
 
+const forgotPasswordDeleteEndToEndEncryptedData = (username) => {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+
+    const method = 'POST'
+    const url = `${config.getEndpoint()}/api/auth/forgot-password-delete-end-to-end-encrypted-data?appId=${config.getAppId()}&username=${encodeURIComponent(username)}&userbaseJsVersion=${config.USERBASE_JS_VERSION}`
+
+    xhr.open(method, url)
+    xhr.send()
+
+    processXhr(xhr, resolve, reject)
+  })
+}
+
 export default {
   signUp,
   getPasswordSalts,
@@ -162,4 +176,5 @@ export default {
   signInWithSession,
   getServerPublicKey,
   getPublicKey,
+  forgotPasswordDeleteEndToEndEncryptedData,
 }

--- a/src/userbase-js/src/config.js
+++ b/src/userbase-js/src/config.js
@@ -1,6 +1,6 @@
 import errors from './errors'
 
-const USERBASE_JS_VERSION = '2.3.0'
+const USERBASE_JS_VERSION = '2.4.0'
 
 const VERSION = '/v1'
 const DEFAULT_ENDPOINT = 'https://v1.userbase.com' + VERSION
@@ -10,12 +10,6 @@ const STRIPE_TEST_PUBLISHABLE_KEY = 'pk_test_rYANrLdNfdJXJ2d808wW4pqY'
 
 let userbaseAppId = null
 let userbaseUpdateUserHandler = null
-
-const REMEMBER_ME_OPTIONS = {
-  local: true,
-  session: true,
-  none: true
-}
 
 const getAppId = () => {
   if (!userbaseAppId) throw new errors.AppIdNotSet
@@ -42,7 +36,6 @@ const getStripePublishableKey = (isProduction) => {
 
 export default {
   USERBASE_JS_VERSION,
-  REMEMBER_ME_OPTIONS,
   getAppId,
   getUpdateUserHandler,
   getEndpoint,

--- a/src/userbase-js/src/errors/auth.js
+++ b/src/userbase-js/src/errors/auth.js
@@ -216,7 +216,7 @@ class UserMustChangePassword extends Error {
     super(...params)
 
     this.name = 'UserMustChangePassword'
-    this.message = 'User must change password.'
+    this.message = 'Must change password first.'
     this.status = statusCodes['Forbidden']
   }
 }

--- a/src/userbase-js/src/errors/auth.js
+++ b/src/userbase-js/src/errors/auth.js
@@ -211,6 +211,16 @@ class UserEmailNotFound extends Error {
   }
 }
 
+class UserMustChangePassword extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'UserMustChangePassword'
+    this.message = 'User must change password.'
+    this.status = statusCodes['Forbidden']
+  }
+}
+
 class EmailNotValid extends Error {
   constructor(...params) {
     super(...params)
@@ -357,6 +367,16 @@ class KeyNotFound extends Error {
   }
 }
 
+class DeleteEndToEndEncryptedDataMustBeBoolean extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'DeleteEndToEndEncryptedDataMustBeBoolean'
+    this.message = 'Delete end-to-end encrypted data value must be a boolean.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
 export default {
   UsernameAlreadyExists,
   UsernameMissing,
@@ -379,6 +399,7 @@ export default {
   UserNotSignedIn,
   UserNotFound,
   UserEmailNotFound,
+  UserMustChangePassword,
   EmailNotValid,
   ProfileMustBeObject,
   ProfileCannotBeEmpty,
@@ -393,4 +414,5 @@ export default {
   CurrentPasswordMissing,
   CurrentPasswordIncorrect,
   KeyNotFound,
+  DeleteEndToEndEncryptedDataMustBeBoolean,
 }

--- a/src/userbase-js/src/errors/db.js
+++ b/src/userbase-js/src/errors/db.js
@@ -80,6 +80,16 @@ class ChangeHandlerMustBeFunction extends Error {
   }
 }
 
+class EncryptionModeNotValid extends Error {
+  constructor(options, ...params) {
+    super(options, ...params)
+
+    this.name = 'EncryptionModeNotValid'
+    this.message = `Encryption mode must be one of ${JSON.stringify(Object.keys(options))}.`
+    this.status = statusCodes['Bad Request']
+  }
+}
+
 class DatabaseNotOpen extends Error {
   constructor(...params) {
     super(...params)
@@ -729,6 +739,7 @@ export default {
   RevokeMustBeBoolean,
   ChangeHandlerMissing,
   ChangeHandlerMustBeFunction,
+  EncryptionModeNotValid,
   DatabaseNotOpen,
   ItemMissing,
   ItemInvalid,

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -41,7 +41,7 @@ class Connection {
     this.init()
   }
 
-  init(resolveConnection, rejectConnection, session, seedString, rememberMe, changePassword, state) {
+  init(resolveConnection, rejectConnection, session, seedString, rememberMe, changePassword, state, encryptionMode) {
     if (this.pingTimeout) clearTimeout(this.pingTimeout)
 
     for (const property of Object.keys(this)) {
@@ -84,6 +84,8 @@ class Connection {
       databases: {}, // used when openDatabase is called with databaseName
       databasesByDbId: {} // used when openDatabase is called with databaseId
     }
+
+    this.encryptionMode = encryptionMode
   }
 
   connect(session, seedString = null, rememberMe, changePassword, reconnectDelay, state) {
@@ -128,7 +130,8 @@ class Connection {
             }
 
             case 'Connection': {
-              this.init(resolve, reject, session, seedString, rememberMe, changePassword, state)
+              const { encryptionMode } = message
+              this.init(resolve, reject, session, seedString, rememberMe, changePassword, state, encryptionMode)
               this.ws = ws
               this.heartbeat()
               this.connected = true

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -59,6 +59,7 @@ class Connection {
       username: session && session.username,
       sessionId: session && session.sessionId,
       creationDate: session && session.creationDate,
+      expirationDate: session && session.expirationDate,
       userId: session && session.userId,
       authToken: session && session.authToken,
     }
@@ -150,10 +151,14 @@ class Connection {
                 // still only have a DH key
                 if (encryptedValidationMessage) this.encryptedValidationMessage = new Uint8Array(encryptedValidationMessage.data)
 
-                await this.setKeys(this.seedString)
-
-                const userData = await this.validateKey()
-                this.userData = userData
+                try {
+                  await this.setKeys(this.seedString)
+                  const userData = await this.validateKey()
+                  this.userData = userData
+                } catch (e) {
+                  if ((e && e.name === 'OperationError') || e instanceof DOMException) throw new Error('Invalid seed')
+                  else throw e
+                }
 
                 this.keys.init = true
               }

--- a/src/userbase-js/types/index.d.ts
+++ b/src/userbase-js/types/index.d.ts
@@ -18,6 +18,8 @@ export type PaymentsMode = 'disabled' | 'test' | 'prod'
 
 export type SubscriptionStatus = 'active' | 'trialing' | 'incomplete' | 'incomplete_expired' | 'past_due' | 'canceled' | 'unpaid'
 
+export type EncryptionMode = 'end-to-end' | 'server-side'
+
 export interface UserResult {
   username: string
   userId: string
@@ -32,6 +34,7 @@ export interface UserResult {
   protectedProfile?: UserProfile
   usedTempPassword?: boolean
   passwordChanged?: boolean
+  changePassword?: boolean
 }
 
 export type DatabaseChangeHandler = (items: Item[]) => void
@@ -47,6 +50,7 @@ export interface Database {
   receivedFromUsername?: string
   readOnly: boolean
   resharingAllowed: boolean
+  encryptionMode: EncryptionMode
   users: DatabaseUsers[]
 }
 

--- a/src/userbase-server/admin-panel/App.jsx
+++ b/src/userbase-server/admin-panel/App.jsx
@@ -198,7 +198,7 @@ export default class App extends Component {
 
     return (
       <div>
-        <header className='sm:sticky top-0 bg-white z-50 shadow-md mb-0 sm:mb-8'>
+        <header className='sm:sticky top-0 bg-white z-40 shadow-md mb-0 sm:mb-8'>
           <div className='sm:flex sm:justify-between sm:items-center py-2 px-4'>
             <div className='flex items-center justify-between h-10'>
               <div className='flex-shrink-0'>

--- a/src/userbase-server/admin-panel/components/Admin/logic.js
+++ b/src/userbase-server/admin-panel/components/Admin/logic.js
@@ -69,13 +69,14 @@ const createAdmin = async (email, password, fullName, receiveEmailUpdates) => {
   }
 }
 
-const createApp = async (appName) => {
+const createApp = async (appName, encryptionMode) => {
   try {
     const appResponse = await axios({
       method: 'POST',
       url: `/${VERSION}/admin/create-app`,
       data: {
-        appName
+        appName,
+        encryptionMode,
       },
       timeout: TEN_SECONDS_MS
     })

--- a/src/userbase-server/admin-panel/components/Dashboard/EncryptionModeModal.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/EncryptionModeModal.jsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { func } from 'prop-types'
+
+// source: https://tailwindui.com/components/application-ui/overlays/modals
+const EncryptionModeModal = ({ handleHideEncryptionModeModal }) => {
+  return (
+    <div className="fixed z-50 inset-0 overflow-y-auto">
+      <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-32 text-center sm:block sm:p-0">
+
+        <div className="fixed inset-0 transition-opacity" aria-hidden="true">
+          <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
+        </div>
+
+        <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+        <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+
+          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+            <div className="sm:flex sm:items-start">
+              <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                <h2 className="text-xl leading-6 font-bold text-gray-900">
+                  Encryption Modes
+                </h2>
+
+                <h3 className="text-lg leading-6 font-medium text-gray-900 mt-4">
+                  End-to-end <span className='text-sm font-light'>(Default)</span>
+                </h3>
+                <div className="mt-2">
+                  <p className="text-sm text-gray-500">
+                    Userbase encrypts all database operations in the browser with user-controlled keys. No one but your users and the people they share data with can access their encrypted data, not even us. Sounds great, right? It is, but it comes with a serious tradeoff: if a user forgets their password and loses access to their device, their data cannot be recovered. With this mode, we recommend that you inform your users that since their data is end-to-end encrypted, they should take care to store their password in a safe place, such as a password manager. End-to-end encryption helps you prevent personal data misuse, and lets you offer a high level of data privacy.
+                  </p>
+                </div>
+
+                <h3 className="text-lg leading-6 font-medium text-gray-900">
+                  Server-side
+                </h3>
+                <div className="mt-2">
+                  <p className="text-sm text-gray-500">
+                    Userbase encrypts data on the wire and at rest before storing it. If a user forgets their password in this mode, they can simply reset it and continue using their account with all their data, just like normal. The tradeoff with this mode is that the server has access to your users&apos; data. This mode still protects you from personal data misuse, and offers a higher level of data privacy than most comparable services.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="bg-gray-50 px-4 py-2 pb-6 sm:px-6 sm:flex sm:flex-row-reverse">
+            <input
+              className='btn inline-flex text-center justify-center w-full sm:w-24 select-none'
+              type='submit'
+              value='Close'
+              onClick={handleHideEncryptionModeModal}
+            />
+            <input
+              className='btn inline-flex text-center justify-center w-full mt-3 sm:mt-0 sm:w-24 sm:mr-4 select-none'
+              type='submit'
+              value='Learn more'
+              onClick={() => window.open('https://userbase.com/docs/faq/', '_blank')}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+EncryptionModeModal.propTypes = {
+  handleHideEncryptionModeModal: func,
+}
+
+export default EncryptionModeModal

--- a/src/userbase-server/admin-panel/components/Dashboard/logic.js
+++ b/src/userbase-server/admin-panel/components/Dashboard/logic.js
@@ -189,6 +189,18 @@ const disablePayments = async (appName, appId) => {
   }
 }
 
+const modifyEncryptionMode = async (appId, appName, encryptionMode) => {
+  try {
+    await axios({
+      method: 'POST',
+      url: `/${VERSION}/admin/apps/${appId}/encryption-mode?appName=${encodeURIComponent(appName)}&encryptionMode=${encodeURIComponent(encryptionMode)}`,
+      timeout: TEN_SECONDS_MS
+    })
+  } catch (e) {
+    adminLogic.errorHandler(e)
+  }
+}
+
 export default {
   listApps,
   listAppUsers,
@@ -203,4 +215,5 @@ export default {
   enableTestPayments,
   enableProdPayments,
   disablePayments,
+  modifyEncryptionMode,
 }

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -557,7 +557,7 @@ exports.forgotPassword = async function (req, res) {
       + 'If you did not make this request, you can safely ignore this email.'
       + '<br />'
       + '<br />'
-      + `Here is your temporary password you can use to log in: ${tempPassword}`
+      + `Here is your temporary password you can use to sign in: ${tempPassword}`
       + '<br />'
       + '<br />'
       + `This password will expire in ${HOURS_IN_A_DAY} hours.`

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -633,6 +633,7 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/access-token', admin.authenticateAdmin, admin.generateAccessToken)
     v1Admin.delete('/access-token', admin.authenticateAdmin, admin.deleteAccessToken)
     v1Admin.get('/account', admin.authenticateAdmin, admin.getAdminAccount)
+    v1Admin.post('/apps/:appId/encryption-mode', admin.authenticateAdmin, appController.modifyEncryptionMode)
 
     // endpoints for admin to manage their own account's payments to Userbase
     v1Admin.post('/stripe/create-saas-payment-session', admin.authenticateAdmin, admin.createSaasPaymentSession)
@@ -723,8 +724,8 @@ function createAdmin({ email, password, fullName, adminId, receiveEmailUpdates, 
   return admin.createAdmin(email, password, fullName, adminId, receiveEmailUpdates, storePasswordInSecretsManager)
 }
 
-function createApp({ appName, adminId, appId }) {
-  return appController.createApp(appName, adminId, appId)
+function createApp({ appName, adminId, encryptionMode, appId }) {
+  return appController.createApp(appName, adminId, encryptionMode, appId)
 }
 
 export default {

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -96,7 +96,7 @@ async function start(express, app, userbaseConfig = {}) {
         const connectionId = conn.id
 
         const connectionLogObject = { userId, connectionId, adminId, appId, userbaseJsVersion, sessionId, changePassword: changePassword ? true : undefined, route: 'Connection' }
-        const validationMessage = userController.sendConnection(connectionLogObject, ws, res.locals.user)
+        const validationMessage = userController.sendConnection(connectionLogObject, ws, res.locals.user, res.locals.app)
 
         ws.on('close', () => connections.close(conn))
 

--- a/src/userbase-server/user.js
+++ b/src/userbase-server/user.js
@@ -2835,7 +2835,7 @@ exports.updatePaymentMethod = async function (logChildObject, app, admin, user, 
   }
 }
 
-exports.sendConnection = function (connectionLogObject, ws, user) {
+exports.sendConnection = function (connectionLogObject, ws, user, app) {
   const validationMessage = crypto.randomBytes(VALIDATION_MESSAGE_LENGTH)
 
   const keySalts = {
@@ -2846,6 +2846,7 @@ exports.sendConnection = function (connectionLogObject, ws, user) {
   const webSocketMessage = {
     route: 'Connection',
     keySalts,
+    encryptionMode: app['encryption-mode'] || 'end-to-end',
   }
 
   if (user['ecdsa-public-key']) {

--- a/src/userbase-server/ws.js
+++ b/src/userbase-server/ws.js
@@ -405,7 +405,7 @@ export default class Connections {
 
     if (!conn.databases[databaseId]) {
       conn.openDatabase(databaseId, dbNameHash, bundleSeqNo, reopenAtSeqNo, isOwner, attribution)
-      logger.child({ connectionId, databaseId, adminId: conn.adminId }).info('Database opened')
+      logger.child({ connectionId, databaseId, adminId: conn.adminId, encryptionMode: plaintextDbKey ? 'server-side' : 'end-to-end' }).info('Database opened')
     }
 
     conn.push(databaseId, dbNameHash, dbKey, reopenAtSeqNo, plaintextDbKey)


### PR DESCRIPTION
Admins can now set their apps' encryption mode to either 'end-to-end' (the default), or 'server-side'. The 'end-to-end' encryption mode is the mode all apps that currently exist are set to. The 'server-side' mode is a new mode that allows users who forget their password to reset it **and maintain access to their data**, without needing access to a previously used device. This is our most requested feature at the moment. Here's what it looks like in the Admin panel:

<img width="1275" alt="Screen Shot 2020-11-19 at 9 11 12 PM" src="https://user-images.githubusercontent.com/26468430/100085538-00e84880-2e01-11eb-9e69-31325a66f98b.png">

<img width="1275" alt="Screen Shot 2020-11-19 at 9 11 47 PM" src="https://user-images.githubusercontent.com/26468430/100085489-f332c300-2e00-11eb-9da3-03894f5796fc.png">

![Screen Shot 2020-11-19 at 9 12 43 PM](https://user-images.githubusercontent.com/26468430/100085583-0fcefb00-2e01-11eb-85f7-648ff0d5a0bd.png)



## Additional highlights in this PR

- getDatabases() returns each database's `encryptionMode`.
- sign() returns a boolean `changePassword` if the user needs to change their password to access database and payments functions in the SDK.
- forgotPassword() accepts a new optional parameter `deleteEndToEndEncryptedData` to allow users of an app with encryption mode set to 'end-to-end' who forget their password and lose access to their device to regain access to their account. (#118)
- openDatabase(), insertItem(), updateItem(), putTransaction(), uploadFile(), and getFile() all take a new optional parameter `encryptionMode` to override an app's default behavior for a database.

### Bug fixes

- signIn() signs in correctly when a user provides the correct password but their seed stored in browser storage is incorrect, rather than throw ServiceUnavailable.
- init() returns the `lastUsedUsername` when a user's seed stored in browser storage is incorrect, rather than throw ServiceUnavailable.