### PR TITLE
Allow server side encryption param in init()

### DIFF
--- a/src/userbase-js/CHANGELOG.md
+++ b/src/userbase-js/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.4.2] - 2020-12-02
+### Fixed
+- init() now accepts a parameter `allowServerSideEncryption` in order for the SDK to create and interact with databases in the 'server-side' encryption mode. This prevents a dishonest server from maliciously changing an app's encryption mode to server-side, thereby causing clients to store new data in plaintext.
+
 ## [2.4.1] - 2020-11-30
 ### Changed
 - modifyDatabasePermissions() now accepts self if user wants to revoke own access to database.
@@ -9,7 +13,7 @@
 ### Added
 - Encryption modes 'end-to-end' or 'server-side' set by the admin in the Admin panel are respected by the client. Databases created in 'end-to-end' mode remain end-to-end encrypted same as before (the default behavior). Databases created in 'server-side' mode store the plaintext database encryption key on the server; these databases can be recovered if a user forgets their password and loses access to their device.
 - getDatabases() returns a database's `encryptionMode`.
-- sign() returns a boolean `changePassword` if the user needs to change their password to access database and payments functions in the SDK.
+- signIn() returns a boolean `changePassword` if the user needs to change their password to access database and payments functions in the SDK.
 - forgotPassword() accepts a new optional parameter `deleteEndToEndEncryptedData` to allow users of an app with encryption mode set to 'end-to-end' who forget their password and lose access to their device to regain access to their account.
 - openDatabase(), insertItem(), updateItem(), putTransaction(), uploadFile(), and getFile() all take a new optional parameter `encryptionMode` to override an app's default behavior for a database.
 

--- a/src/userbase-js/src/auth.js
+++ b/src/userbase-js/src/auth.js
@@ -527,6 +527,10 @@ const init = async (params) => {
       throw new errors.SessionLengthMustBeNumber
     }
 
+    if (objectHasOwnProperty(params, 'allowServerSideEncryption') && typeof params.allowServerSideEncryption !== 'boolean') {
+      throw new errors.AllowServerSideEncryptionMustBeBoolean
+    }
+
     config.configure(params)
 
     const session = await signInWithSession(params.appId, _calculateSessionLengthMs(params.sessionLength))
@@ -545,6 +549,7 @@ const init = async (params) => {
       case 'SessionLengthMustBeNumber':
       case 'SessionLengthTooShort':
       case 'SessionLengthTooLong':
+      case 'AllowServerSideEncryptionMustBeBoolean':
       case 'UserAlreadySignedIn':
       case 'ServiceUnavailable':
         throw e

--- a/src/userbase-js/src/config.js
+++ b/src/userbase-js/src/config.js
@@ -1,6 +1,6 @@
 import errors from './errors'
 
-const USERBASE_JS_VERSION = '2.4.0'
+const USERBASE_JS_VERSION = '2.4.2'
 
 const VERSION = '/v1'
 const DEFAULT_ENDPOINT = 'https://v1.userbase.com' + VERSION
@@ -10,6 +10,7 @@ const STRIPE_TEST_PUBLISHABLE_KEY = 'pk_test_rYANrLdNfdJXJ2d808wW4pqY'
 
 let userbaseAppId = null
 let userbaseUpdateUserHandler = null
+let userbaseAllowServerSideEncryptionMode = false
 
 const getAppId = () => {
   if (!userbaseAppId) throw new errors.AppIdNotSet
@@ -22,10 +23,11 @@ const getEndpoint = () => {
   return window._userbaseEndpoint || DEFAULT_ENDPOINT
 }
 
-const configure = ({ appId, updateUserHandler }) => {
+const configure = ({ appId, updateUserHandler, allowServerSideEncryption }) => {
   if (userbaseAppId && userbaseAppId !== appId) throw new errors.AppIdAlreadySet(userbaseAppId)
   userbaseAppId = appId
   userbaseUpdateUserHandler = updateUserHandler
+  userbaseAllowServerSideEncryptionMode = allowServerSideEncryption
 }
 
 const getStripePublishableKey = (isProduction) => {
@@ -34,6 +36,8 @@ const getStripePublishableKey = (isProduction) => {
     : (window._USERBASE_STRIPE_TEST_PUBLISHABLE_KEY || STRIPE_TEST_PUBLISHABLE_KEY)
 }
 
+const isServerSideEncryptionModeAllowed = () => userbaseAllowServerSideEncryptionMode
+
 export default {
   USERBASE_JS_VERSION,
   getAppId,
@@ -41,4 +45,5 @@ export default {
   getEndpoint,
   configure,
   getStripePublishableKey,
+  isServerSideEncryptionModeAllowed,
 }

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -8,6 +8,7 @@ import statusCodes from './statusCodes'
 import { byteSizeOfString, Queue, objectHasOwnProperty } from './utils'
 import { arrayBufferToString, stringToArrayBuffer } from './Crypto/utils'
 import api from './api'
+import config from './config'
 
 const success = 'Success'
 
@@ -626,6 +627,12 @@ const _createDatabase = async (dbName, encryptionMode) => {
   return newDatabaseParams
 }
 
+const _validateEncryptionMode = (encryptionMode) => {
+  if (encryptionMode === 'server-side' && !config.isServerSideEncryptionModeAllowed()) {
+    throw new errors.ServerSideEncryptionNotEnabledInClient
+  }
+}
+
 const _validateDbName = (dbName) => {
   if (typeof dbName !== 'string') throw new errors.DatabaseNameMustBeString
   if (dbName.length === 0) throw new errors.DatabaseNameCannotBeBlank
@@ -673,6 +680,7 @@ const openDatabase = async (params) => {
     const { databaseName, databaseId, changeHandler, encryptionMode = ws.encryptionMode } = params
 
     if (typeof changeHandler !== 'function') throw new errors.ChangeHandlerMustBeFunction
+    _validateEncryptionMode(encryptionMode)
 
     if (databaseName) {
       const dbNameHash = encryptionMode === 'server-side'
@@ -708,6 +716,7 @@ const openDatabase = async (params) => {
       case 'ChangeHandlerMissing':
       case 'ChangeHandlerMustBeFunction':
       case 'EncryptionModeNotValid':
+      case 'ServerSideEncryptionNotEnabledInClient':
       case 'UserMustChangePassword':
       case 'UserNotSignedIn':
       case 'UserNotFound':
@@ -727,6 +736,8 @@ const openDatabase = async (params) => {
 }
 
 const getOpenDb = (dbName, databaseId, encryptionMode = 'end-to-end') => {
+  _validateEncryptionMode(encryptionMode)
+
   const dbNameHash = encryptionMode === 'server-side' ? dbName : ws.state.dbNameToHash[dbName]
   const database = dbName
     ? ws.state.databases[dbNameHash]
@@ -763,6 +774,7 @@ const insertItem = async (params) => {
       case 'DatabaseIdNotAllowed':
       case 'DatabaseIsReadOnly':
       case 'EncryptionModeNotValid':
+      case 'ServerSideEncryptionNotEnabledInClient':
       case 'ItemIdMustBeString':
       case 'ItemIdCannotBeBlank':
       case 'ItemIdTooLong':
@@ -834,6 +846,7 @@ const updateItem = async (params) => {
       case 'DatabaseIdNotAllowed':
       case 'DatabaseIsReadOnly':
       case 'EncryptionModeNotValid':
+      case 'ServerSideEncryptionNotEnabledInClient':
       case 'ItemIdMissing':
       case 'ItemIdMustBeString':
       case 'ItemIdCannotBeBlank':
@@ -907,6 +920,7 @@ const deleteItem = async (params) => {
       case 'DatabaseIdNotAllowed':
       case 'DatabaseIsReadOnly':
       case 'EncryptionModeNotValid':
+      case 'ServerSideEncryptionNotEnabledInClient':
       case 'ItemIdMissing':
       case 'ItemIdMustBeString':
       case 'ItemIdCannotBeBlank':
@@ -1012,6 +1026,7 @@ const putTransaction = async (params) => {
       case 'DatabaseIdNotAllowed':
       case 'DatabaseIsReadOnly':
       case 'EncryptionModeNotValid':
+      case 'ServerSideEncryptionNotEnabledInClient':
       case 'OperationsMissing':
       case 'OperationsMustBeArray':
       case 'OperationsConflict':
@@ -1239,6 +1254,7 @@ const uploadFile = async (params) => {
       case 'DatabaseIdNotAllowed':
       case 'DatabaseIsReadOnly':
       case 'EncryptionModeNotValid':
+      case 'ServerSideEncryptionNotEnabledInClient':
       case 'ItemIdMissing':
       case 'ItemIdMustBeString':
       case 'ItemIdCannotBeBlank':
@@ -1397,6 +1413,7 @@ const getFile = async (params) => {
       case 'DatabaseIdNotAllowed':
       case 'DatabaseIsReadOnly':
       case 'EncryptionModeNotValid':
+      case 'ServerSideEncryptionNotEnabledInClient':
       case 'FileIdMissing':
       case 'FileIdMustBeString':
       case 'FileIdCannotBeBlank':
@@ -1648,6 +1665,7 @@ const getDatabases = async (params) => {
     const username = ws.session.username
 
     const encryptionMode = (params && params.encryptionMode) || ws.encryptionMode
+    _validateEncryptionMode(encryptionMode)
 
     try {
       const databases = []
@@ -1689,6 +1707,7 @@ const getDatabases = async (params) => {
       case 'DatabaseIdInvalidLength':
       case 'DatabaseIdNotAllowed':
       case 'EncryptionModeNotValid':
+      case 'ServerSideEncryptionNotEnabledInClient':
       case 'UserMustChangePassword':
       case 'UserNotSignedIn':
       case 'ServiceUnavailable':
@@ -1701,6 +1720,8 @@ const getDatabases = async (params) => {
 }
 
 const _getDatabase = async (databaseName, databaseId, encryptionMode = 'end-to-end') => {
+  _validateEncryptionMode(encryptionMode)
+
   let database
   try {
     // check if database is already open in memory
@@ -1793,6 +1814,7 @@ const shareDatabase = async (params) => {
     _validateDbSharingInput(params)
 
     const { databaseName, databaseId, encryptionMode = ws.encryptionMode } = params
+    _validateEncryptionMode(encryptionMode)
     const username = params.username.toLowerCase()
     const readOnly = objectHasOwnProperty(params, 'readOnly') ? params.readOnly : true
     const resharingAllowed = objectHasOwnProperty(params, 'resharingAllowed') ? params.resharingAllowed : false
@@ -1899,6 +1921,7 @@ const shareDatabase = async (params) => {
       case 'DatabaseIdNotAllowed':
       case 'DatabaseNotFound':
       case 'EncryptionModeNotValid':
+      case 'ServerSideEncryptionNotEnabledInClient':
       case 'UsernameMissing':
       case 'UsernameCannotBeBlank':
       case 'UsernameMustBeString':
@@ -1995,6 +2018,7 @@ const modifyDatabasePermissions = async (params) => {
       case 'DatabaseIdNotAllowed':
       case 'DatabaseNotFound':
       case 'EncryptionModeNotValid':
+      case 'ServerSideEncryptionNotEnabledInClient':
       case 'UsernameMissing':
       case 'UsernameCannotBeBlank':
       case 'UsernameMustBeString':

--- a/src/userbase-js/src/errors/auth.js
+++ b/src/userbase-js/src/errors/auth.js
@@ -150,6 +150,16 @@ class SessionLengthTooLong extends Error {
   }
 }
 
+class AllowServerSideEncryptionMustBeBoolean extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'AllowServerSideEncryptionMustBeBoolean'
+    this.message = 'Allow server-side encryption value must be a boolean.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
 class UserAlreadySignedIn extends Error {
   constructor(username, ...params) {
     super(...params)
@@ -393,6 +403,7 @@ export default {
   SessionLengthMustBeNumber,
   SessionLengthTooShort,
   SessionLengthTooLong,
+  AllowServerSideEncryptionMustBeBoolean,
   UserAlreadySignedIn,
   UserPendingDeletion,
   AppIdNotValid,

--- a/src/userbase-js/src/errors/db.js
+++ b/src/userbase-js/src/errors/db.js
@@ -90,6 +90,16 @@ class EncryptionModeNotValid extends Error {
   }
 }
 
+class ServerSideEncryptionNotEnabledInClient extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'ServerSideEncryptionNotEnabledInClient'
+    this.message = 'Server-side encryption must be enabled in the client to use it. To enable it, set allowServerSideEncryption to true in init().'
+    this.status = statusCodes['Forbidden']
+  }
+}
+
 class DatabaseNotOpen extends Error {
   constructor(...params) {
     super(...params)
@@ -740,6 +750,7 @@ export default {
   ChangeHandlerMissing,
   ChangeHandlerMustBeFunction,
   EncryptionModeNotValid,
+  ServerSideEncryptionNotEnabledInClient,
   DatabaseNotOpen,
   ItemMissing,
   ItemInvalid,

--- a/src/userbase-js/types/index.d.ts
+++ b/src/userbase-js/types/index.d.ts
@@ -112,7 +112,7 @@ export interface CancelSubscriptionResult {
 export type databaseNameXorId = ({ databaseId: string, databaseName?: never } | { databaseName: string, databaseId?: never });
 
 export interface Userbase {
-  init(params: { appId: string, updateUserHandler?: UpdateUserHandler, sessionLength?: number }): Promise<Session>
+  init(params: { appId: string, updateUserHandler?: UpdateUserHandler, sessionLength?: number, allowServerSideEncryption?: boolean }): Promise<Session>
 
   signUp(params: { username: string, password: string, email?: string, profile?: UserProfile, rememberMe?: RememberMeOption, sessionLength?: number }): Promise<UserResult>
 

--- a/src/userbase-server/purge.js
+++ b/src/userbase-server/purge.js
@@ -226,7 +226,7 @@ const _deleteConnectedStripeCustomer = async (customerId, stripeAccount, useTest
       await stripe.getClient(useTestClient).customers.del(customerId, { stripeAccount })
     } catch (e) {
       // only ok to let fail if customer is already deleted
-      if (e.message !== 'No such customer: ' + customerId) throw e
+      if (e.message !== `No such customer: '${customerId}'`) throw e
     }
   }
 }
@@ -446,7 +446,7 @@ const _deleteStripeCustomer = async (customerId) => {
       await stripe.getClient().customers.del(customerId)
     } catch (e) {
       // only ok to let fail if customer is already deleted
-      if (e.message !== 'No such customer: ' + customerId) throw e
+      if (e.message !== `No such customer: '${customerId}'`) throw e
     }
   }
 }

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -731,7 +731,7 @@ async function start(express, app, userbaseConfig = {}) {
       await wait(Math.random() * 8000)
       return start(express, app, userbaseConfig = {})
     } else {
-      logger.child(e).fatal('Unhandled error while launching server')
+      logger.child(e).fatal(`Unhandled error while launching server ${e}`)
     }
   }
 }

--- a/src/userbase-server/utils.js
+++ b/src/userbase-server/utils.js
@@ -58,7 +58,7 @@ export const estimateSizeOfDdbItem = (item) => {
   return bytes
 }
 
-export const trimReq = (req) => ({ id: req.id, url: req.url })
+export const trimReq = (req) => ({ id: req.id, url: req.url, headers: req.headers })
 
 export const truncateSessionId = (sessionId) => typeof sessionId === 'string' && sessionId.substring(0, 8) // limit sensitive logging
 


### PR DESCRIPTION
init() requires `allowServerSideEncryption` param when an app is set to the server-side encryption mode, or a developer uses the server-side encryption mode at all.