### PR TITLE
Item-level access control (#208)

### DIFF
--- a/cypress/integration/Database Sharing/access-control.spec.js
+++ b/cypress/integration/Database Sharing/access-control.spec.js
@@ -1,0 +1,1446 @@
+import { getRandomString, getStringOfByteLength, wait } from '../../support/utils'
+const BUNDLE_SIZE = 50 * 1024 // from src/userbase-server/ws.js
+
+const beforeEachHook = function () {
+  cy.visit('./cypress/integration/index.html').then(async function (win) {
+    expect(win).to.have.property('userbase')
+    const userbase = win.userbase
+    this.currentTest.userbase = userbase
+    this.currentTest.win = win
+
+    const { appId, endpoint } = Cypress.env()
+    win._userbaseEndpoint = endpoint
+    userbase.init({ appId })
+  })
+}
+
+const signUp = async (userbase) => {
+  const username = 'test-user-' + getRandomString()
+  const password = getRandomString()
+
+  await userbase.signUp({
+    username,
+    password,
+    rememberMe: 'none'
+  })
+
+  return { username, password }
+}
+
+describe('DB Sharing Tests', function () {
+  const databaseName = 'test-db'
+
+  describe('Write access', function () {
+
+    describe('Sucess Tests', function () {
+      beforeEach(function () { beforeEachHook() })
+
+      it('Item creator can update item', async function () {
+        const user = await signUp(this.test.userbase)
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { onlyCreator: true }
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          if (changeHandlerCallCount) {
+            expect(items, 'array passed to changeHandler').to.be.a('array')
+
+            const expectedItem = {
+              itemId: testItemId,
+              item: testItem + (changeHandlerCallCount === 1 ? '' : '!'),
+              writeAccess,
+              createdBy: { username: user.username, timestamp: items[0].createdBy.timestamp },
+            }
+            if (changeHandlerCallCount === 2) expectedItem.updatedBy = { username: user.username, timestamp: items[0].updatedBy.timestamp }
+            expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+          }
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.updateItem({ databaseName, item: testItem + '!', itemId: testItemId })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(3)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Item creator can set write access via updateItem', async function () {
+        const user = await signUp(this.test.userbase)
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { onlyCreator: true }
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          if (changeHandlerCallCount) {
+            expect(items, 'array passed to changeHandler').to.be.a('array')
+
+            const expectedItem = {
+              itemId: testItemId,
+              item: testItem + (changeHandlerCallCount === 1 ? '' : '!'),
+              createdBy: { username: user.username, timestamp: items[0].createdBy.timestamp },
+            }
+            if (changeHandlerCallCount === 2) {
+              expectedItem.writeAccess = writeAccess
+              expectedItem.updatedBy = { username: user.username, timestamp: items[0].updatedBy.timestamp }
+            }
+            expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+          }
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId })
+        await this.test.userbase.updateItem({ databaseName, item: testItem + '!', itemId: testItemId, writeAccess })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(3)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Item creator can set write access via transaction', async function () {
+        const user = await signUp(this.test.userbase)
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { onlyCreator: true }
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          if (changeHandlerCallCount) {
+            expect(items, 'array passed to changeHandler').to.be.a('array')
+
+            const expectedItem = {
+              itemId: testItemId,
+              item: testItem + (changeHandlerCallCount === 1 ? '' : '!'),
+              createdBy: { username: user.username, timestamp: items[0].createdBy.timestamp },
+            }
+            if (changeHandlerCallCount === 2) {
+              expectedItem.writeAccess = writeAccess
+              expectedItem.updatedBy = { username: user.username, timestamp: items[0].updatedBy.timestamp }
+            }
+            expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+          }
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId })
+        await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: testItem + '!', itemId: testItemId, writeAccess }] })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(3)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Give recipient write access', async function () {
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const sender = await signUp(this.test.userbase)
+
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: recipient.username }] }
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+
+          if (changeHandlerCallCount) {
+            const expectedItem = {
+              itemId: testItemId,
+              item: testItem,
+              writeAccess,
+              createdBy: { username: sender.username, timestamp: items[0].createdBy.timestamp },
+            }
+            expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+          }
+
+          changeHandlerCallCount += 1
+        }
+
+        // insert with write access into database
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(2)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Recipient can update item', async function () {
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: recipient.username }] }
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+
+        await this.test.userbase.signOut()
+
+        // recipient signs in and checks if can update the item
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+
+          const expectedItem = {
+            itemId: testItemId,
+            item: testItem + (changeHandlerCallCount === 0 ? '' : '!'),
+            writeAccess,
+            createdBy: { username: sender.username, timestamp: items[0].createdBy.timestamp },
+          }
+          if (changeHandlerCallCount === 1) expectedItem.updatedBy = { username: recipient.username, timestamp: items[0].updatedBy.timestamp }
+          expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+        await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(2)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Both item creator and recipient can update item', async function () {
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: recipient.username }] }
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.updateItem({ databaseName, item: testItem + '!', itemId: testItemId })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+
+        await this.test.userbase.signOut()
+
+        // recipient signs in and checks if can update the item
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+
+          const expectedItem = {
+            itemId: testItemId,
+            item: testItem + (changeHandlerCallCount === 0 ? '!' : '!!'),
+            writeAccess,
+            createdBy: { username: sender.username, timestamp: items[0].createdBy.timestamp },
+            updatedBy: changeHandlerCallCount === 0
+              ? { username: sender.username, timestamp: items[0].updatedBy.timestamp }
+              : { username: recipient.username, timestamp: items[0].updatedBy.timestamp },
+          }
+          expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+        await this.test.userbase.updateItem({ shareToken, item: testItem + '!!', itemId: testItemId })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(2)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Item creator can remove write access setting', async function () {
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { onlyCreator: true }
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.updateItem({ databaseName, item: testItem, itemId: testItemId, writeAccess: null })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        // recipient signs up and checks if can update the item
+        const recipient = await signUp(this.test.userbase)
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+
+          const expectedItem = {
+            itemId: testItemId,
+            item: testItem + (changeHandlerCallCount === 0 ? '' : '!'),
+            createdBy: { username: sender.username, timestamp: items[0].createdBy.timestamp },
+            updatedBy: changeHandlerCallCount === 0
+              ? { username: sender.username, timestamp: items[0].updatedBy.timestamp }
+              : { username: recipient.username, timestamp: items[0].updatedBy.timestamp },
+          }
+          expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+        await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(2)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Item creator can remove write access inside a transaction', async function () {
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { onlyCreator: true }
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: testItem, itemId: testItemId, writeAccess: null }] })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        // recipient signs up and checks if can update the item
+        const recipient = await signUp(this.test.userbase)
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+
+          const expectedItem = {
+            itemId: testItemId,
+            item: testItem + (changeHandlerCallCount === 0 ? '' : '!'),
+            createdBy: { username: sender.username, timestamp: items[0].createdBy.timestamp },
+            updatedBy: changeHandlerCallCount === 0
+              ? { username: sender.username, timestamp: items[0].updatedBy.timestamp }
+              : { username: recipient.username, timestamp: items[0].updatedBy.timestamp },
+          }
+          expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+        await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(2)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Database owner can modify item', async function () {
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        // recipient signs up and inserts with write access to only allow self to update
+        const recipient = await signUp(this.test.userbase)
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { onlyCreator: true }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler: () => { } })
+        await this.test.userbase.insertItem({ shareToken, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.signOut()
+
+        // sender signs back in and modifes the item
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+
+          const expectedItem = {
+            itemId: testItemId,
+            item: testItem + (changeHandlerCallCount === 0 ? '' : '!'),
+            writeAccess,
+            createdBy: { username: recipient.username, timestamp: items[0].createdBy.timestamp },
+          }
+          if (changeHandlerCallCount === 1) expectedItem.updatedBy = { username: sender.username, timestamp: items[0].updatedBy.timestamp }
+          expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+        await this.test.userbase.updateItem({ databaseName, item: testItem + '!', itemId: testItemId })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(2)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Database owner can remove write access', async function () {
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        // recipient signs up and inserts with write access to only allow self to update
+        const recipient = await signUp(this.test.userbase)
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { onlyCreator: true }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler: () => { } })
+        await this.test.userbase.insertItem({ shareToken, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.signOut()
+
+        // sender signs back in and modifes the item
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+
+          const expectedItem = {
+            itemId: testItemId,
+            item: testItem,
+            writeAccess,
+            createdBy: { username: recipient.username, timestamp: items[0].createdBy.timestamp },
+          }
+          if (changeHandlerCallCount === 1) {
+            expectedItem.updatedBy = { username: sender.username, timestamp: items[0].updatedBy.timestamp }
+            delete expectedItem.writeAccess
+          }
+          expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+        await this.test.userbase.updateItem({ databaseName, item: testItem, itemId: testItemId, writeAccess: null })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(2)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Database owner can remove write access inside a transaction', async function () {
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        // recipient signs up and inserts with write access to only allow self to update
+        const recipient = await signUp(this.test.userbase)
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { onlyCreator: true }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler: () => { } })
+        await this.test.userbase.insertItem({ shareToken, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.signOut()
+
+        // sender signs back in and modifes the item
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+
+          const expectedItem = {
+            itemId: testItemId,
+            item: testItem,
+            writeAccess,
+            createdBy: { username: recipient.username, timestamp: items[0].createdBy.timestamp },
+          }
+          if (changeHandlerCallCount === 1) {
+            expectedItem.updatedBy = { username: sender.username, timestamp: items[0].updatedBy.timestamp }
+            delete expectedItem.writeAccess
+          }
+          expect(items, 'array passed to changeHandler').to.deep.equal([expectedItem])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+        await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: testItem, itemId: testItemId, writeAccess: null }] })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(2)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Write access onlyCreator setting remains after bundling', async function () {
+        const user = await signUp(this.test.userbase)
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { onlyCreator: true }
+
+        const ITEM_SIZE = 5 * 1024 // can be anything so long as BUNDLE_SIZE / ITEM_SIZE < 10
+        const numItemsNeededToTriggerBundle = BUNDLE_SIZE / ITEM_SIZE
+        expect(numItemsNeededToTriggerBundle, 'items needed to trigger bundle').to.be.lte(10) // max operations allowed in tx
+
+        const largeString = getStringOfByteLength(ITEM_SIZE)
+        const operations = []
+        for (let i = 0; i < numItemsNeededToTriggerBundle; i++) {
+          operations.push({ command: 'Insert', item: largeString, itemId: i.toString() })
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.putTransaction({ databaseName, operations })
+
+        // give client sufficient time to finish the bundle
+        const THREE_SECONDS = 3 * 1000
+        await wait(THREE_SECONDS)
+        await this.test.userbase.signOut()
+
+        await this.test.userbase.signIn({ username: user.username, password: user.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array').with.lengthOf(numItemsNeededToTriggerBundle + 1)
+
+          for (let i = 0; i < items.length; i++) {
+            const item = items[i]
+            if (i === 0) {
+              expect(item, 'first item').to.deep.equal({
+                itemId: testItemId,
+                item: testItem,
+                writeAccess,
+                createdBy: { username: user.username, timestamp: items[i].createdBy.timestamp },
+              })
+            } else {
+              expect(item, 'other items').to.deep.equal({
+                itemId: operations[i - 1].itemId,
+                item: largeString,
+                createdBy: { username: user.username, timestamp: items[i].createdBy.timestamp },
+              })
+            }
+          }
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Write access users setting remains after bundling', async function () {
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const user = await signUp(this.test.userbase)
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: recipient.username }] }
+
+        const ITEM_SIZE = 5 * 1024 // can be anything so long as BUNDLE_SIZE / ITEM_SIZE < 10
+        const numItemsNeededToTriggerBundle = BUNDLE_SIZE / ITEM_SIZE
+        expect(numItemsNeededToTriggerBundle, 'items needed to trigger bundle').to.be.lte(10) // max operations allowed in tx
+
+        const largeString = getStringOfByteLength(ITEM_SIZE)
+        const operations = []
+        for (let i = 0; i < numItemsNeededToTriggerBundle; i++) {
+          operations.push({ command: 'Insert', item: largeString, itemId: i.toString() })
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.putTransaction({ databaseName, operations })
+
+        // give client sufficient time to finish the bundle
+        const THREE_SECONDS = 3 * 1000
+        await wait(THREE_SECONDS)
+        await this.test.userbase.signOut()
+
+        await this.test.userbase.signIn({ username: user.username, password: user.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array').with.lengthOf(numItemsNeededToTriggerBundle + 1)
+
+          for (let i = 0; i < items.length; i++) {
+            const item = items[i]
+            if (i === 0) {
+              expect(item, 'first item').to.deep.equal({
+                itemId: testItemId,
+                item: testItem,
+                writeAccess,
+                createdBy: { username: user.username, timestamp: items[i].createdBy.timestamp },
+              })
+            } else {
+              expect(item, 'other items').to.deep.equal({
+                itemId: operations[i - 1].itemId,
+                item: largeString,
+                createdBy: { username: user.username, timestamp: items[i].createdBy.timestamp },
+              })
+            }
+          }
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Write access users setting remains after bundling and changing name', async function () {
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const user = await signUp(this.test.userbase)
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: recipient.username }] }
+
+        const ITEM_SIZE = 5 * 1024 // can be anything so long as BUNDLE_SIZE / ITEM_SIZE < 10
+        const numItemsNeededToTriggerBundle = BUNDLE_SIZE / ITEM_SIZE
+        expect(numItemsNeededToTriggerBundle, 'items needed to trigger bundle').to.be.lte(10) // max operations allowed in tx
+
+        const largeString = getStringOfByteLength(ITEM_SIZE)
+        const operations = []
+        for (let i = 0; i < numItemsNeededToTriggerBundle; i++) {
+          operations.push({ command: 'Insert', item: largeString, itemId: i.toString() })
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.putTransaction({ databaseName, operations })
+
+        // give client sufficient time to finish the bundle
+        const THREE_SECONDS = 3 * 1000
+        await wait(THREE_SECONDS)
+        await this.test.userbase.signOut()
+
+        // update recipient's username
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        const newUsername = 'test-user-' + getRandomString()
+        await this.test.userbase.updateUser({ username: newUsername })
+        recipient.username = newUsername
+        await this.test.userbase.signOut()
+
+        // sign back in and check that write access correctly reflects new username
+        await this.test.userbase.signIn({ username: user.username, password: user.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array').with.lengthOf(numItemsNeededToTriggerBundle + 1)
+
+          for (let i = 0; i < items.length; i++) {
+            const item = items[i]
+            if (i === 0) {
+              expect(item, 'first item').to.deep.equal({
+                itemId: testItemId,
+                item: testItem,
+                writeAccess: { users: [{ username: recipient.username }] },
+                createdBy: { username: user.username, timestamp: items[i].createdBy.timestamp },
+              })
+            } else {
+              expect(item, 'other items').to.deep.equal({
+                itemId: operations[i - 1].itemId,
+                item: largeString,
+                createdBy: { username: user.username, timestamp: items[i].createdBy.timestamp },
+              })
+            }
+          }
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+    })
+
+    describe('Failure Tests', function () {
+      beforeEach(function () { beforeEachHook() })
+
+      it('Transaction Unauthorized - only the item creator can modify the item', async function () {
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert with write access set to onlyCreator
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { onlyCreator: true }
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        // recipient signs in and checks if can modify the item
+        await signUp(this.test.userbase)
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+          expect(items, 'array passed to changeHandler').to.deep.equal([{
+            itemId: testItemId,
+            item: testItem,
+            writeAccess,
+            createdBy: { username: sender.username, timestamp: items[0].createdBy.timestamp },
+          }])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId, writeAccess })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.deleteItem({ shareToken, itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'deleteItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.uploadFile({ shareToken, itemId: testItemId, file: new this.test.win.File([1], 'test.txt') })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'uploadFile' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Update', item: testItem + '!', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Update' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Delete', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Delete' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Transaction Unauthorized - user explicitly not given permission', async function () {
+        const unusedUser = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: unusedUser.username }] }
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        // recipient signs in and checks if can update the item
+        await signUp(this.test.userbase)
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+          expect(items, 'array passed to changeHandler').to.deep.equal([{
+            itemId: testItemId,
+            item: testItem,
+            writeAccess,
+            createdBy: { username: sender.username, timestamp: items[0].createdBy.timestamp },
+          }])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId, writeAccess })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.deleteItem({ shareToken, itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'deleteItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.uploadFile({ shareToken, itemId: testItemId, file: new this.test.win.File([1], 'test.txt') })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'uploadFile' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Update', item: testItem + '!', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Update' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Delete', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Delete' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: unusedUser.username, password: unusedUser.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it("Transaction Unauthorized - item creator removes user's write access", async function () {
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert with write access granted to recipient, and then remove access
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: recipient.username }] }
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.updateItem({ databaseName, item: testItem, itemId: testItemId, writeAccess: { onlyCreator: true } })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+          expect(items, 'array passed to changeHandler').to.deep.equal([{
+            itemId: testItemId,
+            item: testItem,
+            writeAccess: { onlyCreator: true },
+            createdBy: { username: sender.username, timestamp: items[0].createdBy.timestamp },
+            updatedBy: { username: sender.username, timestamp: items[0].updatedBy.timestamp },
+          }])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId, writeAccess })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.deleteItem({ shareToken, itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'deleteItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.uploadFile({ shareToken, itemId: testItemId, file: new this.test.win.File([1], 'test.txt') })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'uploadFile' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Update', item: testItem + '!', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Update' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Delete', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Delete' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it("Transaction Unauthorized - item creator removes user's write access via transaction", async function () {
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert with write access granted to recipient, and then remove access
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: recipient.username }] }
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: testItem, itemId: testItemId, writeAccess: { onlyCreator: true } }] })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+          expect(items, 'array passed to changeHandler').to.deep.equal([{
+            itemId: testItemId,
+            item: testItem,
+            writeAccess: { onlyCreator: true },
+            createdBy: { username: sender.username, timestamp: items[0].createdBy.timestamp },
+            updatedBy: { username: sender.username, timestamp: items[0].updatedBy.timestamp },
+          }])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId, writeAccess })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.deleteItem({ shareToken, itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'deleteItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.uploadFile({ shareToken, itemId: testItemId, file: new this.test.win.File([1], 'test.txt') })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'uploadFile' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Update', item: testItem + '!', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Update' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Delete', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Delete' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Transaction Unauthorized - database owner removes write access', async function () {
+        const userA = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const userB = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const owner = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // owner gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        // userA inserts item with writeAccess
+        await this.test.userbase.signIn({ username: userA.username, password: userA.password, rememberMe: 'none' })
+        await this.test.userbase.openDatabase({ shareToken, changeHandler: () => { } })
+
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: userB.username }] }
+        await this.test.userbase.insertItem({ shareToken, item: testItem, itemId: testItemId, writeAccess })
+        await this.test.userbase.signOut()
+
+        // owner signs in and changes writeAccess to onlyCreator
+        await this.test.userbase.signIn({ username: owner.username, password: owner.password, rememberMe: 'none' })
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+        await this.test.userbase.updateItem({ databaseName, item: testItem, itemId: testItemId, writeAccess: { onlyCreator: true } })
+        await this.test.userbase.signOut()
+
+        // userB shouldn't have write access
+        await this.test.userbase.signIn({ username: userB.username, password: userB.password, rememberMe: 'none' })
+        await this.test.userbase.openDatabase({ shareToken, changeHandler: () => { } })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+          expect(items, 'array passed to changeHandler').to.deep.equal([{
+            itemId: testItemId,
+            item: testItem,
+            writeAccess: { onlyCreator: true },
+            createdBy: { username: userA.username, timestamp: items[0].createdBy.timestamp },
+            updatedBy: { username: owner.username, timestamp: items[0].updatedBy.timestamp },
+          }])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.deleteItem({ shareToken, itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'deleteItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.uploadFile({ shareToken, itemId: testItemId, file: new this.test.win.File([1], 'test.txt') })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'uploadFile' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Update', item: testItem + '!', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Update' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Delete', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Delete' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: userA.username, password: userA.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: owner.username, password: owner.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Transaction Unauthorized - write access setting remains after bundling', async function () {
+        const unusedUser = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const sender = await signUp(this.test.userbase)
+
+        // insert with write access provided to unused user
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: unusedUser.username }] }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+
+        // Trigger bundle
+        const ITEM_SIZE = 5 * 1024 // can be anything so long as BUNDLE_SIZE / ITEM_SIZE < 10
+        const numItemsNeededToTriggerBundle = BUNDLE_SIZE / ITEM_SIZE
+        expect(numItemsNeededToTriggerBundle, 'items needed to trigger bundle').to.be.lte(10) // max operations allowed in tx
+
+        const largeString = getStringOfByteLength(ITEM_SIZE)
+        const operations = []
+        for (let i = 0; i < numItemsNeededToTriggerBundle; i++) {
+          operations.push({ command: 'Insert', item: largeString, itemId: i.toString() })
+        }
+        await this.test.userbase.putTransaction({ databaseName, operations })
+
+        // give client sufficient time to finish the bundle
+        const THREE_SECONDS = 3 * 1000
+        await wait(THREE_SECONDS)
+        await this.test.userbase.signOut()
+
+        // recipient should not be able to update the item
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array').with.lengthOf(numItemsNeededToTriggerBundle + 1)
+
+          for (let i = 0; i < items.length; i++) {
+            const item = items[i]
+            if (i === 0) {
+              expect(item, 'first item').to.deep.equal({
+                itemId: testItemId,
+                item: testItem,
+                writeAccess,
+                createdBy: { username: sender.username, timestamp: items[i].createdBy.timestamp },
+              })
+            } else {
+              expect(item, 'other items').to.deep.equal({
+                itemId: operations[i - 1].itemId,
+                item: largeString,
+                createdBy: { username: sender.username, timestamp: items[i].createdBy.timestamp },
+              })
+            }
+          }
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId, writeAccess })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'updateItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.deleteItem({ shareToken, itemId: testItemId })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'deleteItem' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.uploadFile({ shareToken, itemId: testItemId, file: new this.test.win.File([1], 'test.txt') })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'uploadFile' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Update', item: testItem + '!', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Update' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Delete', itemId: testItemId }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('TransactionUnauthorized')
+          expect(e.message, 'error message').to.be.equal("Calling 'Delete' on this item is unauthorized.")
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: unusedUser.username, password: unusedUser.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('WriteAccessParamNotAllowed - only item creator or owner can set write access', async function () {
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId })
+
+        // sender gets database share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        // recipient signs in and checks if can update the item
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array')
+          expect(items, 'array passed to changeHandler').to.deep.equal([{
+            itemId: testItemId,
+            item: testItem,
+            createdBy: { username: sender.username, timestamp: items[0].createdBy.timestamp },
+          }])
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId, writeAccess: null })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('WriteAccessParamNotAllowed')
+          expect(e.message, 'error message').to.be.equal(`Write access parameter not allowed. Only the item creator or database owner can change an item's write access settings.`)
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.updateItem({ shareToken, item: testItem + '!', itemId: testItemId, writeAccess: { onlyCreator: true } })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('WriteAccessParamNotAllowed')
+          expect(e.message, 'error message').to.be.equal(`Write access parameter not allowed. Only the item creator or database owner can change an item's write access settings.`)
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Update', item: testItem + '!', itemId: testItemId, writeAccess: null }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('WriteAccessParamNotAllowed')
+          expect(e.message, 'error message').to.be.equal(`Write access parameter not allowed. Only the item creator or database owner can change an item's write access settings.`)
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ shareToken, operations: [{ command: 'Update', item: testItem + '!', itemId: testItemId, writeAccess: { onlyCreator: true } }] })
+        } catch (e) {
+          expect(e.name, 'error name').to.be.equal('WriteAccessParamNotAllowed')
+          expect(e.message, 'error message').to.be.equal(`Write access parameter not allowed. Only the item creator or database owner can change an item's write access settings.`)
+          expect(e.status, 'error status').to.be.equal(403)
+        }
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('User not found - does not exist', async function () {
+        await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const fakeUsername = 'fake-user'
+        const writeAccess = { users: [{ username: fakeUsername }] }
+
+        try {
+          await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        } catch (e) {
+          expect(e.username, 'error username').to.be.equal(fakeUsername)
+          expect(e.name, 'error name').to.be.equal('UserNotFound')
+          expect(e.message, 'error message').to.be.equal("User not found.")
+          expect(e.status, 'error status').to.be.equal(404)
+        }
+        // clean up
+        await this.test.userbase.deleteUser()
+      })
+
+      it('User not found - deleted', async function () {
+        const deletedUser = await signUp(this.test.userbase)
+        await this.test.userbase.deleteUser()
+
+        await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // insert, then update item with write access into database
+        const testItem = 'hello world!'
+        const testItemId = 'test-id'
+        const writeAccess = { users: [{ username: deletedUser.username }] }
+
+        try {
+          await this.test.userbase.insertItem({ databaseName, item: testItem, itemId: testItemId, writeAccess })
+        } catch (e) {
+          expect(e.username, 'error username').to.be.equal(deletedUser.username)
+          expect(e.name, 'error name').to.be.equal('UserNotFound')
+          expect(e.message, 'error message').to.be.equal("User not found.")
+          expect(e.status, 'error status').to.be.equal(404)
+        }
+        // clean up
+        await this.test.userbase.deleteUser()
+      })
+
+    })
+
+  })
+
+})

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -372,9 +372,7 @@ class Database {
       let userIsAuthorized = false
       const { onlyCreator, users } = writeAccess
 
-      if (modifiedByUserId === ownerId) {
-        userIsAuthorized = true
-      } else if (onlyCreator && modifiedByUserId === createdByUserId) {
+      if (modifiedByUserId === ownerId || modifiedByUserId === createdByUserId) {
         userIsAuthorized = true
       } else if (!onlyCreator && users) {
         for (const { userId } of users) {

--- a/src/userbase-js/src/errors/auth.js
+++ b/src/userbase-js/src/errors/auth.js
@@ -212,8 +212,10 @@ class UserNotSignedIn extends Error {
 }
 
 class UserNotFound extends Error {
-  constructor(...params) {
-    super(...params)
+  constructor(username, ...params) {
+    super(username, ...params)
+
+    if (username) this.username = username
 
     this.name = 'UserNotFound'
     this.message = 'User not found.'

--- a/src/userbase-js/src/errors/db.js
+++ b/src/userbase-js/src/errors/db.js
@@ -770,6 +770,26 @@ class ProgressHandlerMustBeFunction extends Error {
   }
 }
 
+class TransactionUnauthorized extends Error {
+  constructor(command, ...params) {
+    super(command, ...params)
+
+    this.name = 'TransactionUnauthorized'
+    this.message = `Calling '${command}' on this item is unauthorized.`
+    this.status = statusCodes['Forbidden']
+  }
+}
+
+class WriteAccessParamNotAllowed extends Error {
+  constructor(command, ...params) {
+    super(command, ...params)
+
+    this.name = 'WriteAccessParamNotAllowed'
+    this.message = `Write access parameter not allowed. Only the item creator or database owner can change an item's write access settings.`
+    this.status = statusCodes['Forbidden']
+  }
+}
+
 export default {
   DatabaseNameMissing,
   DatabaseNameCannotBeBlank,
@@ -848,4 +868,6 @@ export default {
   VerificationMessageInvalid,
   VerifyingSelfNotAllowed,
   ProgressHandlerMustBeFunction,
+  TransactionUnauthorized,
+  WriteAccessParamNotAllowed,
 }

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -227,7 +227,7 @@ class Connection {
               }
 
               const newTransactions = message.transactionLog
-              await database.applyTransactions(newTransactions)
+              await database.applyTransactions(newTransactions, message.ownerId)
 
               if (!database.init) {
                 database.dbId = dbId

--- a/src/userbase-js/types/index.d.ts
+++ b/src/userbase-js/types/index.d.ts
@@ -69,12 +69,14 @@ export interface InsertOperation {
   command: 'Insert'
   itemId?: string
   item: any
+  writeAccess?: AccessControl
 }
 
 export interface UpdateOperation {
   command: 'Update'
   itemId: string
   item: any
+  writeAccess?: AccessControl | null | false | undefined
 }
 
 export interface DeleteOperation {
@@ -91,12 +93,18 @@ export interface Item {
   fileName?: string
   fileSize?: number
   fileUploadedBy?: Attribution
+  writeAccess?: AccessControl
 }
 
 export interface Attribution {
   timestamp: Date
   username?: string
   userDeleted?: boolean
+}
+
+export interface AccessControl {
+  onlyCreator?: boolean
+  users?: [{ username?: string }]
 }
 
 export interface FileResult {
@@ -128,7 +136,7 @@ export interface Userbase {
 
   signOut(): Promise<void>
 
-  updateUser(params: { username?: string, currentPassword?: string, newPassword?: string, email?: string | null, profile?: UserProfile | null }): Promise<void>
+  updateUser(params: { username?: string, currentPassword?: string, newPassword?: string, email?: string | null | false | undefined, profile?: UserProfile | null | false | undefined }): Promise<void>
 
   deleteUser(): Promise<void>
 
@@ -138,9 +146,9 @@ export interface Userbase {
 
   getDatabases(params?: databaseNameXorId): Promise<DatabasesResult>
 
-  insertItem(params: databaseNameXorIdXorShareToken & { item: any, itemId?: string }): Promise<void>
+  insertItem(params: databaseNameXorIdXorShareToken & { item: any, itemId?: string, writeAccess?: AccessControl }): Promise<void>
 
-  updateItem(params: databaseNameXorIdXorShareToken & { item: any, itemId: string }): Promise<void>
+  updateItem(params: databaseNameXorIdXorShareToken & { item: any, itemId: string, writeAccess?: AccessControl | null | false | undefined }): Promise<void>
 
   deleteItem(params: databaseNameXorIdXorShareToken & { itemId: string }): Promise<void>
 

--- a/src/userbase-js/types/test.ts
+++ b/src/userbase-js/types/test.ts
@@ -172,6 +172,12 @@ insertItem({ databaseName: 'tdb', item: { name: 'tname' } })
 // $ExpectType Promise<void>
 insertItem({ databaseName: 'tdb', item: { name: 'tname' }, itemId: 'tid' })
 
+// $ExpectType Promise<void>
+insertItem({ databaseName: 'tdb', item: { name: 'tname' }, writeAccess: { users: [{ username: 'tuser' }] } })
+
+// $ExpectType Promise<void>
+insertItem({ databaseName: 'tdb', item: { name: 'tname' }, writeAccess: { onlyCreator: true } })
+
 // $ExpectError
 insertItem({ databaseName: 'tdb', item: { name: 'tname' }, itemId: 1 })
 
@@ -180,6 +186,12 @@ insertItem({ item: { name: 'tname' } })
 
 // $ExpectType Promise<void>
 updateItem({ databaseName: 'tdb', item: { name: 'tname' }, itemId: 'tid' })
+
+// $ExpectType Promise<void>
+updateItem({ databaseName: 'tdb', item: { name: 'tname' }, itemId: 'tid', writeAccess: { onlyCreator: true } })
+
+// $ExpectType Promise<void>
+updateItem({ databaseName: 'tdb', item: { name: 'tname' }, itemId: 'tid', writeAccess: false })
 
 // $ExpectError
 updateItem({ databaseName: 'tdb', item: { name: 'tname' } })
@@ -205,7 +217,9 @@ putTransaction({
   operations: [
     { command: 'Insert', item: { name: 'tname' } },
     { command: 'Update', item: { name: 'tname' }, itemId: 'tid' },
-    { command: 'Delete', itemId: 'tid' }
+    { command: 'Delete', itemId: 'tid' },
+    { command: 'Insert', item: { name: 'tname' }, writeAccess: { onlyCreator: true } },
+    { command: 'Update', item: { name: 'tname' }, itemId: 'tid', writeAccess: false },
   ]
 })
 

--- a/src/userbase-server/db.js
+++ b/src/userbase-server/db.js
@@ -28,6 +28,8 @@ const MS_IN_A_DAY = SECONDS_IN_A_DAY * 1000
 
 const VALIDATION_MESSAGE_LENGTH = 16
 
+const MAX_USERS_ALLOWED_FOR_ACCESS_CONTROL = 10
+
 const getS3DbStateKey = (databaseId, bundleSeqNo) => `${databaseId}/${bundleSeqNo}`
 const getS3DbWritersKey = (databaseId, bundleSeqNo) => `${databaseId}/writers/${bundleSeqNo}`
 const getS3FileChunkKey = (databaseId, fileId, chunkNumber) => `${databaseId}/${fileId}/${chunkNumber}`
@@ -224,7 +226,8 @@ exports.openDatabase = async function (user, app, admin, connectionId, dbNameHas
     const plaintextDbKey = database['plaintext-db-key']
 
     const isOwner = true
-    if (connections.openDatabase({ userId, connectionId, databaseId, bundleSeqNo, dbNameHash, dbKey, reopenAtSeqNo, isOwner, attribution, plaintextDbKey })) {
+    const ownerId = userId
+    if (connections.openDatabase({ userId, connectionId, databaseId, bundleSeqNo, dbNameHash, dbKey, reopenAtSeqNo, isOwner, ownerId, attribution, plaintextDbKey })) {
       return responseBuilder.successResponse('Success!')
     } else {
       throw new Error('Unable to open database')
@@ -275,7 +278,7 @@ exports.openDatabaseByDatabaseId = async function (userAtSignIn, app, admin, con
     const bundleSeqNo = db['bundle-seq-no']
     const attribution = db['attribution']
     const plaintextDbKey = db['plaintext-db-key']
-    const connectionParams = { userId, connectionId, databaseId, bundleSeqNo, reopenAtSeqNo, isOwner, attribution, plaintextDbKey }
+    const connectionParams = { userId, connectionId, databaseId, bundleSeqNo, reopenAtSeqNo, isOwner, ownerId: db['owner-id'], attribution, plaintextDbKey }
     if (validationMessage) {
       const shareTokenReadWritePermissions = _validateAuthTokenSignature(userId, db, validationMessage, signedValidationMessage)
 
@@ -623,6 +626,107 @@ exports.getUserDatabaseByDatabaseId = async function (logChildObject, userId, da
   return response
 }
 
+const _setUserForWriteAccess = function (username, userPromiseIndexes, users) {
+  const promiseIndex = userPromiseIndexes[username]
+  const user = users[promiseIndex]
+
+  if (!user || user['deleted']) throw {
+    status: statusCodes['Not Found'],
+    error: { message: 'UserNotFound', username }
+  }
+
+  return { userId: user['user-id'], username }
+}
+
+const _getUsersForWriteAccess = function (users, appId, userPromises, userPromiseIndexes) {
+  if (users.length > MAX_USERS_ALLOWED_FOR_ACCESS_CONTROL) throw {
+    status: statusCodes['Bad Request'],
+    error: { message: 'WriteAccessUsersExceedMax', max: MAX_USERS_ALLOWED_FOR_ACCESS_CONTROL }
+  }
+
+  for (const u of users) {
+    const username = u.username.toLowerCase()
+    if (typeof userPromiseIndexes[username] !== 'number') {
+      userPromiseIndexes[username] = userPromises.push(userController.getUser(appId, username)) - 1
+    }
+  }
+}
+
+const _prepareTransactionForStorage = function (transaction) {
+  const { command } = transaction
+  if (command === 'Insert' || command === 'Update') {
+    const writeAccess = transaction['write-access']
+    if (writeAccess) {
+      return {
+        ...transaction,
+        ['write-access']: {
+          ...writeAccess,
+          users: writeAccess.users
+            ? writeAccess.users.map(u => u.userId) // only need to store array of user ID's
+            : undefined
+        }
+      }
+    }
+  } else if (command === 'BatchTransaction') {
+    return {
+      ...transaction,
+      operations: transaction.operations.map(op => {
+        const { writeAccess } = op
+        return {
+          ...op,
+          writeAccess: (writeAccess && writeAccess.users)
+            ? {
+              ...writeAccess,
+              users: writeAccess.users.map(u => u.userId) // only need to store array of user ID's
+            }
+            : writeAccess
+        }
+      })
+    }
+  }
+  return transaction
+}
+
+const _setUsersForWriteAccess = async function (transaction, appId) {
+  const { command } = transaction
+
+  const userPromises = []
+  const userPromiseIndexes = {}
+
+  if (command === 'Insert' || command === 'Update') {
+    const writeAccess = transaction['write-access']
+
+    if (writeAccess && writeAccess.users) {
+      _getUsersForWriteAccess(writeAccess.users, appId, userPromises, userPromiseIndexes)
+      const users = await Promise.all(userPromises)
+      transaction['write-access'].users = writeAccess.users.map(u => _setUserForWriteAccess(u.username.toLowerCase(), userPromiseIndexes, users))
+    }
+  } else if (command === 'BatchTransaction') {
+    const { operations } = transaction
+    for (const op of operations) {
+      const users = op.writeAccess && op.writeAccess.users
+      if (users && (op.command === 'Insert' || op.command === 'Update')) {
+        _getUsersForWriteAccess(users, appId, userPromises, userPromiseIndexes)
+      }
+    }
+
+    const users = await Promise.all(userPromises)
+
+    transaction.operations = operations.map(op => {
+      const { writeAccess } = op
+      return (writeAccess && writeAccess.users)
+        ? {
+          ...op,
+          writeAccess: {
+            ...writeAccess,
+            users: writeAccess.users.map(u => _setUserForWriteAccess(u.username.toLowerCase(), userPromiseIndexes, users))
+          }
+        }
+        : { ...op }
+    })
+  }
+}
+
 const _incrementSeqNo = async function (transaction, databaseId) {
   const incrementSeqNoParams = {
     TableName: setup.databaseTableName,
@@ -650,7 +754,7 @@ const _incrementSeqNo = async function (transaction, databaseId) {
   }
 }
 
-const putTransaction = async function (transaction, userId, connectionId, databaseId) {
+const putTransaction = async function (transaction, userId, connectionId, databaseId, appId) {
   if (!connections.isDatabaseOpen(userId, connectionId, databaseId)) throw {
     status: statusCodes['Bad Request'],
     error: { name: 'DatabaseNotOpen' }
@@ -666,6 +770,7 @@ const putTransaction = async function (transaction, userId, connectionId, databa
   const [userDb, db] = await Promise.all([
     !shareTokenReadWritePermissions && _getUserDatabaseByUserIdAndDatabaseId(userId, databaseId),
     shareTokenReadWritePermissions && findDatabaseByDatabaseId(databaseId),
+    _setUsersForWriteAccess(transaction, appId),
     _incrementSeqNo(transaction, databaseId)
   ])
 
@@ -689,7 +794,7 @@ const putTransaction = async function (transaction, userId, connectionId, databa
       // write the transaction using the next sequence number
       const params = {
         TableName: setup.transactionsTableName,
-        Item: transaction,
+        Item: _prepareTransactionForStorage(transaction),
         ConditionExpression: 'attribute_not_exists(#databaseId)',
         ExpressionAttributeNames: {
           '#databaseId': 'database-id'
@@ -741,36 +846,43 @@ const rollbackAttempt = async function (transaction, ddbClient) {
   }
 }
 
-const doCommand = async function (command, userId, connectionId, databaseId, key, record, fileId, fileEncryptionKey, fileMetadata) {
+const doCommand = async function ({ command, userId, appId, connectionId, databaseId, itemKey, encryptedItem, writeAccess,
+  fileId, fileEncryptionKey, fileMetadata }) {
   if (!databaseId) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing database id')
-  if (!key) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing item key')
+  if (!itemKey) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing item key')
 
   const transaction = {
     'database-id': databaseId,
-    key,
+    key: itemKey,
     command,
   }
 
-  switch (command) {
-    case 'Insert':
-    case 'Update':
-    case 'Delete': {
-      transaction.record = record
-      break
-    }
-    case 'UploadFile': {
-      transaction['file-id'] = fileId
-      transaction['file-encryption-key'] = fileEncryptionKey
-      transaction['file-metadata'] = fileMetadata
-      break
-    }
-    default: {
-      throw new Error('Unknown command')
-    }
-  }
-
   try {
-    const sequenceNo = await putTransaction(transaction, userId, connectionId, databaseId)
+    switch (command) {
+      case 'Insert':
+      case 'Update': {
+        transaction.record = encryptedItem
+        if (writeAccess || writeAccess === false) {
+          transaction['write-access'] = writeAccess
+        }
+        break
+      }
+      case 'Delete': {
+        transaction.record = encryptedItem
+        break
+      }
+      case 'UploadFile': {
+        transaction['file-id'] = fileId
+        transaction['file-encryption-key'] = fileEncryptionKey
+        transaction['file-metadata'] = fileMetadata
+        break
+      }
+      default: {
+        throw new Error('Unknown command')
+      }
+    }
+
+    const sequenceNo = await putTransaction(transaction, userId, connectionId, databaseId, appId)
     return responseBuilder.successResponse({ sequenceNo })
   } catch (e) {
     const message = `Failed to ${command}`
@@ -803,6 +915,7 @@ exports.batchTransaction = async function (userId, connectionId, databaseId, ope
     const key = operation.itemKey
     const record = operation.encryptedItem
     const command = operation.command
+    const writeAccess = operation.writeAccess
 
     if (!key) return responseBuilder.errorResponse(statusCodes['Bad Request'], `Operation ${i} missing item key`)
     if (!record) return responseBuilder.errorResponse(statusCodes['Bad Request'], `Operation ${i} missing record`)
@@ -811,7 +924,8 @@ exports.batchTransaction = async function (userId, connectionId, databaseId, ope
     ops.push({
       key,
       record,
-      command
+      command,
+      writeAccess,
     })
   }
 
@@ -1052,7 +1166,7 @@ exports.uploadFileChunk = async function (logChildObject, userId, connectionId, 
   }
 }
 
-exports.completeFileUpload = async function (logChildObject, userId, connectionId, databaseId, fileId, fileEncryptionKey, itemKey, fileMetadata) {
+exports.completeFileUpload = async function (logChildObject, userId, appId, connectionId, databaseId, fileId, fileEncryptionKey, itemKey, fileMetadata) {
   try {
     logChildObject.databaseId = databaseId
     logChildObject.fileId = fileId
@@ -1060,8 +1174,8 @@ exports.completeFileUpload = async function (logChildObject, userId, connectionI
     _validateFileUpload(userId, connectionId, databaseId, fileId)
 
     // places transaction in transaction log to attach file to an item
-    const nullRecord = null
-    const response = await doCommand('UploadFile', userId, connectionId, databaseId, itemKey, nullRecord, fileId, fileEncryptionKey, fileMetadata)
+    const command = 'UploadFile'
+    const response = await doCommand({ command, userId, appId, connectionId, databaseId, itemKey, fileId, fileEncryptionKey, fileMetadata })
     return response
   } catch (e) {
     logChildObject.err = e

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -261,14 +261,14 @@ async function start(express, app, userbaseConfig = {}) {
                 case 'Delete': {
                   response = conn.rateLimiter.atCapacity()
                     ? responseBuilder.errorResponse(statusCodes['Too Many Requests'], { retryDelay: 1000 })
-                    : await db.doCommand(
-                      action,
+                    : await db.doCommand({
+                      command: action,
                       userId,
+                      appId,
                       connectionId,
-                      params.dbId,
-                      params.itemKey,
-                      params.encryptedItem
-                    )
+                      databaseId: params.dbId,
+                      ...params
+                    })
                   break
                 }
                 case 'BatchTransaction': {
@@ -306,6 +306,7 @@ async function start(express, app, userbaseConfig = {}) {
                   response = await db.completeFileUpload(
                     logChildObject,
                     userId,
+                    appId,
                     connectionId,
                     params.dbId,
                     params.fileId,

--- a/src/userbase-server/ws.js
+++ b/src/userbase-server/ws.js
@@ -524,6 +524,7 @@ export default class Connections {
             dbId,
             dbNameHash: database.dbNameHash,
             isOwner: database.isOwner,
+            ownerId: database.ownerId,
             writers: database['attribution']
               ? [{ userId: transaction['user-id'], username: transaction['username'] }]
               : undefined

--- a/src/userbase-server/ws.js
+++ b/src/userbase-server/ws.js
@@ -65,7 +65,7 @@ class Connection {
     this.fileStorageRateLimiter = new TokenBucket(FILE_STORAGE_MAX_REQUESTS_PER_SECOND, FILE_STORAGE_TOKENS_REFILLED_PER_SECOND)
   }
 
-  openDatabase(databaseId, dbNameHash, bundleSeqNo, reopenAtSeqNo, isOwner, attribution, shareTokenReadWritePermissions) {
+  openDatabase(databaseId, dbNameHash, bundleSeqNo, reopenAtSeqNo, isOwner, ownerId, attribution, shareTokenReadWritePermissions) {
     this.databases[databaseId] = {
       bundleSeqNo: bundleSeqNo > 0 ? bundleSeqNo : -1,
       lastSeqNo: reopenAtSeqNo || 0,
@@ -73,6 +73,7 @@ class Connection {
       init: reopenAtSeqNo !== undefined, // ensures server sends the dbNameHash & key on first ever push, not reopen
       dbNameHash,
       isOwner,
+      ownerId,
       attribution,
       shareTokenReadWritePermissions,
     }
@@ -92,6 +93,7 @@ class Connection {
       dbId: databaseId,
       dbNameHash: database.dbNameHash,
       isOwner: database.isOwner,
+      ownerId: database.ownerId,
       writers: database.attribution
         ? []
         : undefined,
@@ -112,7 +114,8 @@ class Connection {
     let lastSeqNo = database.lastSeqNo
     const bundleSeqNo = database.bundleSeqNo
 
-    const writerUserIds = new Set()
+    const userIds = new Set() // used for database writers AND writeAccess permissions
+    const writerUserIds = []
 
     if (bundleSeqNo > 0 && database.lastSeqNo === 0) {
       const { bundle, writers } = await db.getBundle(databaseId, bundleSeqNo, database.attribution)
@@ -121,7 +124,8 @@ class Connection {
       lastSeqNo = bundleSeqNo
       if (writers) {
         for (const userId of writers.split(',')) {
-          writerUserIds.add(userId)
+          userIds.add(userId)
+          writerUserIds.push(userId)
         }
       } else if (database.attribution) {
         throw new Error('Missing database bundle writers list')
@@ -156,14 +160,15 @@ class Connection {
           if (database.lastSeqNo < lastSeqNoInBatch) {
 
             for (let i = 0; i < transactionLogResponse.Items.length && !gapInSeqNo; i++) {
+              const transaction = transactionLogResponse.Items[i]
 
               // if there's a gap in sequence numbers and past rollback buffer, rollback all transactions in gap
-              gapInSeqNo = transactionLogResponse.Items[i]['sequence-no'] > lastSeqNo + 1
-              const secondsSinceCreation = gapInSeqNo && new Date() - new Date(transactionLogResponse.Items[i]['creation-date'])
+              gapInSeqNo = transaction['sequence-no'] > lastSeqNo + 1
+              const secondsSinceCreation = gapInSeqNo && new Date() - new Date(transaction['creation-date'])
 
               // waiting gives opportunity for item to insert into DDB
               if (gapInSeqNo && secondsSinceCreation > SECONDS_BEFORE_ROLLBACK_GAP_TRIGGERED) {
-                const rolledBackTransactions = await this.rollback(lastSeqNo, transactionLogResponse.Items[i]['sequence-no'], databaseId, ddbClient)
+                const rolledBackTransactions = await this.rollback(lastSeqNo, transaction['sequence-no'], databaseId, ddbClient)
 
                 for (let j = 0; j < rolledBackTransactions.length; j++) {
 
@@ -178,20 +183,42 @@ class Connection {
                 continue
               }
 
-              lastSeqNo = transactionLogResponse.Items[i]['sequence-no']
+              lastSeqNo = transaction['sequence-no']
 
               // add transaction to the result set if have not sent it to client yet
-              if (transactionLogResponse.Items[i]['sequence-no'] > database.lastSeqNo) {
-                ddbTransactionLog.push(transactionLogResponse.Items[i])
-                if (database.attribution && transactionLogResponse.Items[i].command !== 'Rollback') {
-                  const userId = transactionLogResponse.Items[i]['user-id']
+              if (transaction['sequence-no'] > database.lastSeqNo) {
+                ddbTransactionLog.push(transaction)
+
+                if (database.attribution && transaction.command !== 'Rollback') {
+                  const userId = transaction['user-id']
                   if (userId == null) {
                     throw new Error('Database has attribution, but no user-id on transaction')
                   }
-                  writerUserIds.add(userId)
+
+                  userIds.add(userId)
+                  writerUserIds.push(userId)
+
+                  // check for users set via write access
+                  const { command } = transaction
+                  if (command === 'Insert' || command === 'Update') {
+                    const writeAccess = transaction['write-access']
+                    if (writeAccess && writeAccess.users) {
+                      for (const userIdWithWriteAccess of writeAccess.users) {
+                        userIds.add(userIdWithWriteAccess)
+                      }
+                    }
+                  } else if (command === 'BatchTransaction') {
+                    for (const op of transaction.operations) {
+                      const { writeAccess } = op
+                      if (writeAccess && writeAccess.users) {
+                        for (const userIdWithWriteAccess of writeAccess.users) {
+                          userIds.add(userIdWithWriteAccess)
+                        }
+                      }
+                    }
+                  }
                 }
               }
-
             }
           }
         }
@@ -205,16 +232,26 @@ class Connection {
       throw new Error(e)
     }
 
+    const usersByUserId = {}
     if (database.attribution) {
-      await Promise.all([...writerUserIds].map(getUserByUserId))
-        .then(users => {
-          for (const user of users) {
-            if (!user) continue
-            if (user['deleted']) continue
-            const { 'user-id': userId, username } = user
-            payload.writers.push({ userId, username })
-          }
-        })
+      // get all the users
+      const users = await Promise.all([...userIds].map(getUserByUserId))
+
+      // set users by userId
+      for (const user of users) {
+        if (!user || user['deleted']) continue
+        const { 'user-id': userId } = user
+        usersByUserId[userId] = user
+      }
+
+      // set the writers
+      for (const writerUserId of writerUserIds) {
+        const user = usersByUserId[writerUserId]
+        if (user) {
+          const { 'user-id': userId, username } = user
+          payload.writers.push({ userId, username })
+        }
+      }
     }
 
     if (openingDatabase && database.lastSeqNo !== 0) {
@@ -265,7 +302,7 @@ class Connection {
       return
     }
 
-    this.sendPayload(payload, ddbTransactionLog, database)
+    this.sendPayload(payload, ddbTransactionLog, database, usersByUserId)
   }
 
   async rollback(lastSeqNo, thisSeqNo, databaseId, ddbClient) {
@@ -296,7 +333,7 @@ class Connection {
     return rolledBackTransactions
   }
 
-  sendPayload(payload, ddbTransactionLog, database) {
+  sendPayload(payload, ddbTransactionLog, database, usersByUserId) {
     let size = 0
 
     // only send transactions that have not been sent to client yet
@@ -313,9 +350,38 @@ class Connection {
       .map(transaction => {
         size += estimateSizeOfDdbItem(transaction)
 
+        const { command } = transaction
+        const operations = transaction['operations']
+        const writeAccess = transaction['write-access']
+
+        // set write access usernames using userId
+        if (usersByUserId) {
+          if (command === 'Insert' || command === 'Update') {
+            if (writeAccess && writeAccess.users) {
+              const finalUsers = []
+              for (const userIdWithWriteAccess of writeAccess.users) {
+                const user = usersByUserId[userIdWithWriteAccess]
+                if (user) finalUsers.push({ userId: user['user-id'], username: user['username'] })
+              }
+              writeAccess.users = finalUsers
+            }
+          } else if (command === 'BatchTransaction') {
+            for (const op of transaction.operations) {
+              if (op.writeAccess && op.writeAccess.users) {
+                const finalUsers = []
+                for (const userIdWithWriteAccess of op.writeAccess.users) {
+                  const user = usersByUserId[userIdWithWriteAccess]
+                  if (user) finalUsers.push({ userId: user['user-id'], username: user['username'] })
+                }
+                op.writeAccess.users = finalUsers
+              }
+            }
+          }
+        }
+
         return {
           seqNo: transaction['sequence-no'],
-          command: transaction['command'],
+          command,
           key: transaction['key'],
           record: transaction['record'],
           timestamp: transaction['creation-date'],
@@ -323,8 +389,9 @@ class Connection {
           fileMetadata: transaction['file-metadata'],
           fileId: transaction['file-id'],
           fileEncryptionKey: transaction['file-encryption-key'],
-          operations: transaction['operations'],
-          dbId: transaction['database-id']
+          dbId: transaction['database-id'],
+          operations,
+          writeAccess,
         }
       })
 
@@ -402,14 +469,14 @@ export default class Connections {
     return connection
   }
 
-  static openDatabase({ userId, connectionId, databaseId, bundleSeqNo, dbNameHash, dbKey, reopenAtSeqNo, isOwner,
+  static openDatabase({ userId, connectionId, databaseId, bundleSeqNo, dbNameHash, dbKey, reopenAtSeqNo, isOwner, ownerId,
     attribution, plaintextDbKey, shareTokenEncryptedDbKey, shareTokenEncryptionKeySalt, shareTokenReadWritePermissions }) {
     if (!Connections.sockets || !Connections.sockets[userId] || !Connections.sockets[userId][connectionId]) return
 
     const conn = Connections.sockets[userId][connectionId]
 
     if (!conn.databases[databaseId]) {
-      conn.openDatabase(databaseId, dbNameHash, bundleSeqNo, reopenAtSeqNo, isOwner, attribution, shareTokenReadWritePermissions)
+      conn.openDatabase(databaseId, dbNameHash, bundleSeqNo, reopenAtSeqNo, isOwner, ownerId, attribution, shareTokenReadWritePermissions)
 
       if (!Connections.sockets[databaseId]) Connections.sockets[databaseId] = { numConnections: 0 }
       Connections.sockets[databaseId][connectionId] = userId


### PR DESCRIPTION
This PR enables item creators to set or modify write access permissions on individual items in a database. Thank you to @shamblesides for the feature request in #208!

An item creator can for example only allow themselves to update or delete an item:

```
userbase.insertItem({ 
    databaseName, 
    item, 
    writeAccess: { onlyCreator: true } 
})
```

An item creator can also only allow particular users to update or delete an item:

```
userbase.updateItem({ 
    databaseName,
    itemId,
    item,
    writeAccess: {
        users: [{ username: 'bob' }] 
    }
})
```

The item creator can remove the write access permissions set on an item at any point too.

```
userbase.updateItem({
    databaseName,
    itemId,
    item,
    writeAccess: null 
})
```

Note that the database owner has root privileges, and can override any item-level settings set by an item creator.