### PR TITLE
Bundling process race condition patched

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        browser: ['chrome', 'firefox']
-        # run 8 copies of the current job in parallel
-        containers: [1, 2, 3, 4, 5, 6, 7, 8]
+        # browser: ['chrome', 'firefox'] // can't use firefox until https://github.com/cypress-io/cypress/issues/14600 is fixed
+        browser: ['chrome']
+        # run 10 copies of the current job in parallel
+        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/cypress/integration/Database Correctness/bundling.spec.js
+++ b/cypress/integration/Database Correctness/bundling.spec.js
@@ -1087,8 +1087,8 @@ describe('DB Correctness Tests', function () {
         expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1 + numBundles)
         expect(successful, 'successful state').to.be.true
 
-        // give client sufficient time to finish the bundle
-        const TEN_SECONDS = 10 * 1000
+        console.log('Giving client sufficent time to bundle...')
+        const TEN_SECONDS = 20 * 1000
         await wait(TEN_SECONDS)
 
         await this.test.userbase.signOut()

--- a/cypress/integration/Database Sharing/share-token.spec.js
+++ b/cypress/integration/Database Sharing/share-token.spec.js
@@ -1,4 +1,4 @@
-import { getRandomString } from '../../support/utils'
+import { getRandomString, getOperationsThatTriggerBundle, wait } from '../../support/utils'
 
 const beforeEachHook = function () {
   cy.visit('./cypress/integration/index.html').then(async function (win) {
@@ -468,6 +468,103 @@ describe('DB Sharing Tests', function () {
         await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
         await this.test.userbase.deleteUser()
       })
+
+      it('Owner bundles database, then recipient reads from database', async function () {
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+        const operations = getOperationsThatTriggerBundle()
+        await this.test.userbase.putTransaction({ databaseName, operations })
+
+        console.log('Give client time to finish bundle...')
+        await wait(5000)
+
+        // sender gets share token
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName })
+        await this.test.userbase.signOut()
+
+        // recipient signs in and checks if can read the database
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array').to.have.lengthOf(operations.length)
+
+          for (let i = 0; i < items.length; i++) {
+            const { item, itemId } = operations[i]
+            expect(items[i], 'item passed to change handler').to.deep.equal({
+              itemId,
+              item,
+              createdBy: { username: sender.username, timestamp: items[i].createdBy.timestamp }
+            })
+          }
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
+      it('Recipient bundles database, then owner reads from database', async function () {
+        const recipient = await signUp(this.test.userbase)
+        await this.test.userbase.signOut()
+
+        const sender = await signUp(this.test.userbase)
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        // sender shares database with recipient
+        const { shareToken } = await this.test.userbase.shareDatabase({ databaseName, readOnly: false })
+        await this.test.userbase.signOut()
+
+        // recipient signs in and checks if can read the database
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+
+        await this.test.userbase.openDatabase({ shareToken, changeHandler: () => { } })
+        const operations = getOperationsThatTriggerBundle()
+        await this.test.userbase.putTransaction({ shareToken, operations })
+
+        console.log('Give client time to finish bundle...')
+        await wait(5000)
+        await this.test.userbase.signOut()
+
+        // sender signs back in and reads
+        await this.test.userbase.signIn({ username: sender.username, password: sender.password, rememberMe: 'none' })
+
+        let changeHandlerCallCount = 0
+        const changeHandler = function (items) {
+          expect(items, 'array passed to changeHandler').to.be.a('array').to.have.lengthOf(operations.length)
+
+          for (let i = 0; i < items.length; i++) {
+            const { item, itemId } = operations[i]
+            expect(items[i], 'item passed to change handler').to.deep.equal({
+              itemId,
+              item,
+              createdBy: { username: recipient.username, timestamp: items[i].createdBy.timestamp }
+            })
+          }
+
+          changeHandlerCallCount += 1
+        }
+
+        await this.test.userbase.openDatabase({ databaseName, changeHandler })
+
+        expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(1)
+
+        // clean up
+        await this.test.userbase.deleteUser()
+        await this.test.userbase.signIn({ username: recipient.username, password: recipient.password, rememberMe: 'none' })
+        await this.test.userbase.deleteUser()
+      })
+
 
     })
 

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -13,6 +13,17 @@ export const getRandomStringOfByteLength = (byteLength) => {
   return string
 }
 
+export const getOperationsThatTriggerBundle = () => {
+  const ITEM_SIZE = 5 * 1024
+  const MAX_TRANSACTIONS = 10
+
+  const operations = []
+  for (let i = 0; i < MAX_TRANSACTIONS; i++) {
+    operations.push({ command: 'Insert', item: getRandomStringOfByteLength(ITEM_SIZE), itemId: i.toString() })
+  }
+  return operations
+}
+
 export const wait = (ms) => new Promise(resolve => {
   setTimeout(() => resolve(), ms)
 })

--- a/src/userbase-js/CHANGELOG.md
+++ b/src/userbase-js/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.7.2] - 2021-01-15
+## [2.7.2] - 2021-01-17
 ### Fixed
 - Bundling process (the process that gets triggered when a user has lots of items in a database to speed up database load time) now uploads correctly when concurrent connections attempt to bundle the same database. A race condition was introduced (now fixed) with the optimizations to the bundling process in v2.7.0.
 

--- a/src/userbase-js/CHANGELOG.md
+++ b/src/userbase-js/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2.7.2] - 2021-01-15
+### Fixed
+- Bundling process (the process that gets triggered when a user has lots of items in a database to speed up database load time) now uploads correctly when concurrent connections attempt to bundle the same database. A race condition was introduced (now fixed) with the optimizations to the bundling process in v2.7.0.
+
+## [2.7.1] - 2021-01-13
+### Added
+- Failsafe alerts when reading from a bundle fails unexpectedly.
+
+### Changed
+- Increased allowed time until database operations timeout to increase reliability on slower internet connections.
+
 ## [2.7.0] - 2020-12-30
 ### Added
 - insertItem() now accepts a `writeAccess` object as a parameter, allowing item creators to set access controls on items. The accepted properties to `writeAccess` are a boolean `onlyCreator`, and an array of `users`. `onlyCreator` set to true means only the item creator can update or delete the item. Users provided to the `users` array are the only users allowed to update or delete the item.

--- a/src/userbase-js/src/api/db.js
+++ b/src/userbase-js/src/api/db.js
@@ -1,18 +1,23 @@
 import config from '../config'
 import { processXhr } from './utils'
 
-export const uploadBundleChunk = async (token, userId, databaseId, seqNo, chunkNo, chunk) => {
+const TIMEOUT = 30 * 1000
+
+export const uploadBundleChunk = async (userId, databaseId, seqNo, bundleId, chunkNo, chunk) => {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
 
     const method = 'POST'
-    const url = `${config.getEndpoint()}/api/bundle-chunk?userbaseJsVersion=${config.USERBASE_JS_VERSION}` +
-      `&userId=${userId}&databaseId=${databaseId}&seqNo=${seqNo}&chunkNumber=${chunkNo}`
+    const url = `${config.getEndpoint()}/api/bundle-chunk?userbaseJsVersion=${config.USERBASE_JS_VERSION}&` +
+      `userId=${userId}&` +
+      `databaseId=${databaseId}&` +
+      `seqNo=${seqNo}&` +
+      `bundleId=${bundleId}&` +
+      `chunkNumber=${chunkNo}`
 
     xhr.open(method, url)
-    xhr.setRequestHeader('Authorization', 'Bearer ' + token)
     xhr.send(new Uint8Array(chunk)) // Uint8Array view prevents deprecation warning in Safari
 
-    processXhr(xhr, resolve, reject)
+    processXhr(xhr, resolve, reject, TIMEOUT)
   })
 }

--- a/src/userbase-js/src/api/utils.js
+++ b/src/userbase-js/src/api/utils.js
@@ -39,9 +39,9 @@ const handleResponse = (xhr, resolve, reject) => {
   }
 }
 
-export const processXhr = (xhr, resolve, reject) => {
-  xhr.timeout = TEN_SECONDS_MS
+export const processXhr = (xhr, resolve, reject, timeout = TEN_SECONDS_MS) => {
+  xhr.timeout = timeout
   xhr.onload = () => handleResponse(xhr, resolve, reject)
   xhr.onerror = () => reject(new errors.ServiceUnavailable)
-  xhr.ontimeout = () => reject(new TimeoutError(TEN_SECONDS_MS))
+  xhr.ontimeout = () => reject(new TimeoutError(timeout))
 }

--- a/src/userbase-js/src/config.js
+++ b/src/userbase-js/src/config.js
@@ -1,6 +1,6 @@
 import errors from './errors'
 
-const USERBASE_JS_VERSION = '2.7.0'
+const USERBASE_JS_VERSION = '2.7.2'
 
 const VERSION = '/v1'
 const DEFAULT_ENDPOINT = 'https://v1.userbase.com' + VERSION

--- a/src/userbase-server/utils.js
+++ b/src/userbase-server/utils.js
@@ -139,3 +139,12 @@ export const nextPageTokenToLastEvaluatedKey = (nextPageToken, validateLastEvalu
 }
 
 export const wait = (ms) => new Promise((resolve) => setTimeout(() => resolve(), ms))
+
+// only userbase-js >= 2.7.2 can read and write bundle in chunks
+export const clientCanReadAndWriteBundleChunks = (userbaseJsVersion) => {
+  const version = userbaseJsVersion && userbaseJsVersion.split('.').map(v => Number(v))
+  return version && (version[0] > 2 ||
+    (version[0] === 2 && version[1] > 7) ||
+    (version[0] === 2 && version[1] === 7 && version[2] >= 2)
+  )
+}

--- a/test/browser1/index.html
+++ b/test/browser1/index.html
@@ -432,6 +432,72 @@
       .catch((e) => console.assert(false, e))
   }
 
+  const test6 = (testNum) => {
+    console.log(`%cTest ${testNum}: Browser 1 waits for Browser 2 to insert item that triggers bundling process so they race to bundle, then reads from bundle`, 'font-size: large')
+
+    userbase.init({ appId })
+
+    const { username, password } = USERS[testNum - 1]
+
+    userbase.signUp({ username, password, rememberMe })
+      .then(() => {
+        console.log('Signed up...')
+
+        // set up a promise to wait for another session to insert tx
+        let resolveFirstInsert
+        const waitForFirstInsert = new Promise(resolve => {
+          resolveFirstInsert = resolve
+        })
+
+        let database = []
+        let called = 0
+        let changeHandler = (items) => {
+          database = items
+          called += 1
+
+          if (called === 2) {
+            resolveFirstInsert()
+          }
+        }
+
+        // open the database immediately after signing up
+        userbase.openDatabase({ databaseName, changeHandler })
+          .then(() => {
+
+            console.log('Waiting for first insert...')
+            waitForFirstInsert
+              .then(() => {
+                console.log('Giving client time to finish bundle...')
+                wait(10000).then(() => {
+                  userbase.signOut()
+                    .then(() => {
+                      userbase.signIn({ username, password, rememberMe })
+                        .then(() => {
+                          userbase.openDatabase({
+                            databaseName, changeHandler: function (items) {
+                              assert(items.length, 10, 'array len')
+                              for (let i = 0; i < items.length; i++) {
+                                assert(items[i].itemId, i.toString(), 'item id')
+                              }
+
+                              console.log('Check server to make sure read from bundle!')
+
+                              completedTest(testNum, userbase)
+                            }
+                          })
+                            .catch((e) => console.assert(false, e))
+                        })
+                        .catch((e) => console.assert(false, e))
+                    })
+                    .catch((e) => console.assert(false, e))
+                })
+              })
+          })
+          .catch((e) => console.assert(false, e))
+      })
+      .catch((e) => console.assert(false, e))
+  }
+
   switch (location.hash) {
     case '':
       console.log('%cBrowser 1', 'font-size: x-large; font-weight: bold;')
@@ -452,6 +518,10 @@
 
     case '#test5':
       test5(5)
+      break
+
+    case '#test6':
+      test6(6)
       break
 
     case '#complete':

--- a/test/browser2/index.html
+++ b/test/browser2/index.html
@@ -216,6 +216,63 @@
       })
   }
 
+  const test6 = (testNum) => {
+    console.log(`%cTest ${testNum}: Browser 1 waits for Browser 2 to insert item that triggers bundling process so they race to bundle, then reads from bundle`, 'font-size: large')
+
+    const { username, password } = USERS[testNum - 1]
+
+    userbase.init({ appId })
+
+    wait(SIGN_UP_DELAY)
+      .then(() => {
+        userbase.signIn({ username, password, rememberMe })
+          .then(() => {
+            console.log('Signed in...')
+
+            userbase.openDatabase({ databaseName, changeHandler: () => { } })
+              .then(() => {
+                const operations = getOperationsThatTriggerBundle()
+
+                userbase.putTransaction({ databaseName, operations })
+                  .then(() => {
+                    console.log('Giving client time to finish bundle...')
+                    wait(10000).then(() => {
+                      userbase.signOut()
+                        .then(() => {
+                          userbase.signIn({ username, password, rememberMe })
+                            .then(() => {
+                              userbase.openDatabase({
+                                databaseName, changeHandler: function (items) {
+                                  assert(items.length, operations.length, 'array len')
+                                  for (let i = 0; i < items.length; i++) {
+                                    assert(items[i].itemId, i.toString(), 'item id')
+                                    assert(items[i].item, operations[i].item, 'item')
+                                  }
+
+                                  console.log('Check server to make sure read from bundle!')
+
+                                  completedTest(testNum, userbase)
+                                }
+                              })
+                                .catch((e) => console.assert(false, e))
+                            })
+                            .catch((e) => console.assert(false, e))
+                        })
+                        .catch((e) => console.assert(false, e))
+
+                    })
+
+                  })
+                  .catch((e) => console.assert(false, e))
+
+              })
+              .catch((e) => console.assert(false, e))
+
+          })
+          .catch((e) => console.assert(false, e))
+      })
+  }
+
   if (!location.hash) console.log('%cBrowser 2', 'font-size: x-large; font-weight: bold;')
 
   switch (location.hash) {
@@ -237,6 +294,10 @@
 
     case '#test5':
       test5(5)
+      break
+
+    case '#test6':
+      test6(6)
       break
 
     case '#complete':

--- a/test/development.js
+++ b/test/development.js
@@ -20,3 +20,26 @@ const completedTest = (testNum, userbase) => {
 }
 
 const CONCURRENCY = 150
+
+const getOperationsThatTriggerBundle = () => {
+  const ITEM_SIZE = 5 * 1024 // can be anything so long as BUNDLE_SIZE / ITEM_SIZE < 10
+  const MAX_TRANSACTIONS = 10
+
+  const operations = []
+  for (let i = 0; i < MAX_TRANSACTIONS; i++) {
+    operations.push({ command: 'Insert', item: getRandomStringOfByteLength(ITEM_SIZE), itemId: i.toString() })
+  }
+  return operations
+}
+
+const getRandomString = () => Math.random().toString().substring(2)
+
+const BYTES_IN_STRING = 2
+const getRandomStringOfByteLength = (byteLength) => {
+  const numRandomStrings = byteLength / (getRandomString().length * BYTES_IN_STRING)
+  let string = ''
+  for (let i = 0; i < numRandomStrings; i++) {
+    string += getRandomString()
+  }
+  return string
+}


### PR DESCRIPTION
### The Bundling Process

When a database grows 50kb, the Userbase client will bundle the database up, compress it, encrypt it, then store it on the server. Next time the user signs in and loads their data, they load the database from the bundle for speedy loading. This process is described further [here](https://github.com/smallbets/userbase/blob/e73a90e677f4ddb8e597eef3050778a4c35627c8/docs/userbase_architecture.md#bundling).

### PR Overview

In userbase-js v2.7.0 (#252), a race condition was introduced: if 2 clients were bundling the same database at the same time, it's possible one client could overwrite another's bundle, and then lose the race to store the bundle's encryption key to the other client. So in this rare circumstance, the database wouldn't load the next time a user tries to open it, since the stored encryption key would not correspond to the stored bundle. (edit: to be clear, no users are currently affected by this issue since the bundling process has been disabled temporarily. All clients are safe)

This PR addresses this by allowing both clients to store bundles in separate locations, but only 1 client will win the race to have the location reference stored. Thus, both clients could effectively end up storing duplicate bundles in S3, but only 1 wins. The unreferenced bundles can eventually be garbage collected. This approach avoids an imperfect lock solution.

### Other highlights

- added a test case for the above race condition in the makeshift concurrency test framework (test6 in `/test`)
- added more comprehensive testing to the bundling process
- added more comprehensive logging
- added a failsafe toggle to turn off bundling in production
- only userbase-js clients v2.7.2 and above can read/write bundles now
- all existing S3 bundles and associated references in DDB from before this PR should be deleted before running this server update
