### PR TITLE
Change handler triggers

### DIFF
--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -151,7 +151,7 @@ class Database {
     this.bundleChunks = {}
   }
 
-  async applyTransactions(transactions, ownerId) {
+  async applyTransactions(transactions, ownerId, dbId, dbNameHash) {
     for (let i = 0; i < transactions.length; i++) {
       const transaction = transactions[i]
       const seqNo = transaction.seqNo
@@ -178,7 +178,11 @@ class Database {
     }
 
     if (!this.init) {
+      this.init = true // allows triggers and loaders to be called from within client's changeHandler on database load
+      this.dbId = dbId
+      this.dbNameHash = dbNameHash
       this.onChange(this.getItems())
+      this.receivedMessage() // wait to resolve openDatabase() until changeHandler has received all data
     }
   }
 

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -241,14 +241,7 @@ class Connection {
               }
 
               const newTransactions = message.transactionLog
-              await database.applyTransactions(newTransactions, message.ownerId)
-
-              if (!database.init) {
-                database.dbId = dbId
-                database.dbNameHash = dbNameHash
-                database.init = true
-                database.receivedMessage()
-              }
+              await database.applyTransactions(newTransactions, message.ownerId, dbId, dbNameHash)
 
               if (message.buildBundle) {
                 this.buildBundle(database)


### PR DESCRIPTION
When calling `openDatabase`, the `changeHandler` gets executed before the function returns successfully. This way developers are guaranteed to have all of a database's data loaded before `openDatabase` returns.

Prior to this PR, developers couldn't pass triggers into the `changeHandler` to be executed on database load, or read files on database load. Developers would need to wait until `openDatabase` returned successfully to do anything like that.

This PR allows developers to call triggers or read files on database load, before the `changeHandler` finishes executing.

This is particularly useful in the following case:
- a user needs all their data in a database loaded in succession
- some of the users' data is stored as files
- with this PR, the changeHandler can retrieve a file before moving on to loading the rest of the database