### PR TITLE
Add Optional Generic Type to Item Interface

### DIFF
--- a/src/userbase-js/types/index.d.ts
+++ b/src/userbase-js/types/index.d.ts
@@ -85,9 +85,9 @@ export interface DeleteOperation {
   itemId: string
 }
 
-export interface Item {
+export interface Item<T = any> {
   itemId: string
-  item: any
+  item: T
   createdBy: Attribution
   updatedBy?: Attribution
   fileId?: string


### PR DESCRIPTION
Adding an optional generic type to the Item interface allows developers to optionally declare what type `Item.item` will be. If no type is provided, it defaults to the original type "any".

For example, if I have an interface Book `interface Book { isbn: string; }`, I could define a contract that represents the book as an item saved in a database `type BookItem = Item<Book>`. Lastly, I could use `BookItem` to define the return type from our `changeHandler` in `userbase.openDatabase` like so:
```
userbase.openDatabase({
    databaseName: 'my_database_name',
    changeHandler: (items: BookItem[]) => {
        items.forEach((item: BookItem) => {
            console.log('book isbn: ', item.item.isbn);
        });
    }
});
```