### PR TITLE
blob-polyfill => fetch-blob and use /tmp for LocalStorage

### DIFF
--- a/src/userbase-js-node/index.js
+++ b/src/userbase-js-node/index.js
@@ -7,7 +7,10 @@ global.XMLHttpRequest = require('xhr2')
 
 // localStorage
 const { LocalStorage } = require('node-localstorage')
-global.localStorage = new LocalStorage('./__userbase_localStorage')
+
+// global.localStorage = new LocalStorage('./__userbase_localStorage')
+global.localStorage = new LocalStorage('/tmp/__userbase_localStorage')
+
 
 // sessionStorage
 // https://gist.github.com/juliocesar/926500#gistcomment-1620487
@@ -31,7 +34,8 @@ global.atob = require('atob')
 global.btoa = require('btoa')
 
 // Blob
-global.Blob = require('blob-polyfill').Blob
+// global.Blob = require('blob-polyfill').Blob
+import('fetch-blob').then((blob) => { global.Blob = blob })
 
 // URL.createObjectUrl
 // URL.revokeObjectUrl

--- a/src/userbase-js-node/package.json
+++ b/src/userbase-js-node/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@peculiar/webcrypto": "^1.1.4",
     "atob": "^2.1.2",
-    "blob-polyfill": "^4.0.20200601",
+    "fetch-blob": "^3.2.0",
     "btoa": "^1.2.1",
     "domexception": "^2.0.1",
     "isomorphic-ws": "^4.0.1",


### PR DESCRIPTION
This request proposes to fix two small problems:

- "blob-polyfill" no longer works, generating instead the following error:

      % node index.js 
        xxx/node_modules/blob-polyfill/Blob.js:519
                                  "-ms-scroll-limit" in document.documentElement.style &&
                                                        ^
        ReferenceError: document is not defined
        
- On [Vercel](https://vercel.com) the current directory isn't writable by server-less functions.

To address these issues it:

- replaces "blob-polyfill" with the newer "[fetch-blob](https://www.npmjs.com/package/fetch-blob)"
- moves the parent of LocalStorage to "/tmp"

These changes work for my userbase use-case but would appreciate feedback and/or 
suggestions as to alternative solutions.
